### PR TITLE
K01FR52 and K01FR53 - Validate TxDefaultProfile

### DIFF
--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -71,6 +71,14 @@ public:
     /// \return
     uint32_t get_number_of_connectors();
 
+    /// \brief Returns true if evse_id is 0.
+    /// \return
+    bool is_station_wide() const;
+
+    /// \brief Returns true if evse_id is 0.
+    /// \return
+    static bool is_station_wide_id(int32_t id);
+
     /// \brief Opens a new transaction
     /// \param transaction_id id of the transaction
     /// \param connector_id id of the connector

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -20,7 +20,13 @@ enum class ProfileValidationResultEnum {
     TxProfileEvseIdNotGreaterThanZero,
     TxProfileTransactionNotOnEvse,
     TxProfileEvseHasNoActiveTransaction,
-    TxProfileConflictingStackLevel
+    TxProfileConflictingStackLevel,
+    DuplicateTxDefaultProfileFound
+};
+
+struct EvseProfile {
+    int32_t evse_id;
+    ChargingProfile profile;
 };
 
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
@@ -29,7 +35,7 @@ class SmartChargingHandler {
 private:
     std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
     // cppcheck-suppress unusedStructMember
-    std::vector<ChargingProfile> charging_profiles;
+    std::vector<EvseProfile> charging_profiles;
 
 public:
     explicit SmartChargingHandler();
@@ -37,10 +43,21 @@ public:
     ///
     /// \brief validates the given \p profile according to the specification
     ///
+    ProfileValidationResultEnum validate_tx_default_profile(const ChargingProfile& profile, Evse& evse) const;
+
+    ///
+    /// \brief validates the given \p profile according to the specification
+    ///
     ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, Evse& evse) const;
 
+    ///
     /// \brief Adds a given \p profile to our stored list of profiles
-    void add_profile(const ChargingProfile& profile);
+    ///
+    void add_profile(int32_t evse_id, ChargingProfile& profile);
+
+private:
+    std::vector<EvseProfile> get_evse_specific_tx_default_profiles() const;
+    std::vector<EvseProfile> get_station_wide_tx_default_profiles() const;
 };
 
 } // namespace ocpp::v201

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -62,6 +62,15 @@ EVSE Evse::get_evse_info() {
     return evse;
 }
 
+bool Evse::is_station_wide() const {
+    return is_station_wide_id(evse_id);
+}
+
+bool Evse::is_station_wide_id(int32_t id) {
+    const int32_t STATION_WIDE_ID = 0;
+    return id == STATION_WIDE_ID;
+}
+
 uint32_t Evse::get_number_of_connectors() {
     return static_cast<uint32_t>(this->id_connector_map.size());
 }

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1,6 +1,8 @@
 #include "date/tz.h"
 #include "ocpp/v201/ctrlr_component_variables.hpp"
 #include "ocpp/v201/device_model_storage_sqlite.hpp"
+#include "ocpp/v201/ocpp_types.hpp"
+#include "gtest/gtest.h"
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <filesystem>
@@ -21,7 +23,13 @@
 
 namespace ocpp::v201 {
 
-class ChargepointTestFixtureV201 : public testing::Test {
+static const int STATION_WIDE_ID = 0;
+static const int DEFAULT_EVSE_ID = 1;
+static const int DEFAULT_PROFILE_ID = 1;
+static const int DEFAULT_STACK_LEVEL = 1;
+
+class ChargepointTestFixtureV201
+    : public ::testing::TestWithParam<std::tuple<int, int, int, int, ProfileValidationResultEnum>> {
 protected:
     void SetUp() override {
     }
@@ -47,10 +55,10 @@ protected:
         };
     }
 
-    ChargingProfile create_tx_profile(ChargingSchedule charging_schedule, std::string transaction_id,
-                                      int stack_level = 1) {
-        auto charging_profile_id = 1;
-        auto charging_profile_purpose = ChargingProfilePurposeEnum::TxProfile;
+    ChargingProfile create_charging_profile(int32_t charging_profile_id,
+                                            ChargingProfilePurposeEnum charging_profile_purpose,
+                                            ChargingSchedule charging_schedule, std::string transaction_id,
+                                            int stack_level = DEFAULT_STACK_LEVEL) {
         auto charging_profile_kind = ChargingProfileKindEnum::Absolute;
         auto recurrency_kind = RecurrencyKindEnum::Daily;
         std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
@@ -67,8 +75,8 @@ protected:
     }
 
     ChargingProfile create_tx_profile_with_missing_transaction_id(ChargingSchedule charging_schedule) {
-        auto charging_profile_id = 1;
-        auto stack_level = 1;
+        auto charging_profile_id = DEFAULT_PROFILE_ID;
+        auto stack_level = DEFAULT_STACK_LEVEL;
         auto charging_profile_purpose = ChargingProfilePurposeEnum::TxProfile;
         auto charging_profile_kind = ChargingProfileKindEnum::Absolute;
         auto recurrency_kind = RecurrencyKindEnum::Daily;
@@ -125,42 +133,47 @@ protected:
             std::chrono::seconds(static_cast<int64_t>(1)), std::chrono::seconds(static_cast<int64_t>(1)));
     }
 
+    void install_profile_on_evse(int evse_id, int profile_id) {
+        create_evse_with_id(evse_id);
+        auto existing_profile = create_charging_profile(profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                                        create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+        handler.add_profile(evse_id, existing_profile);
+    }
+
     // Default values used within the tests
     std::map<int32_t, std::unique_ptr<Evse>> evses;
     std::shared_ptr<DatabaseHandler> database_handler;
 
-    const int evse_id = 1;
     bool ignore_no_transaction = true;
-    const int profile_max_stack_level = 1;
-    const int max_charging_profiles_installed = 1;
-    const int charging_schedule_max_periods = 1;
     DeviceModel device_model = create_device_model();
     SmartChargingHandler handler = create_smart_charging_handler();
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 };
 
 TEST_F(ChargepointTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {
-    create_evse_with_id(evse_id);
+    create_evse_with_id(DEFAULT_EVSE_ID);
     auto profile = create_tx_profile_with_missing_transaction_id(create_charge_schedule(ChargingRateUnitEnum::A));
-    auto sut = handler.validate_tx_profile(profile, *evses[evse_id]);
+    auto sut = handler.validate_tx_profile(profile, *evses[DEFAULT_EVSE_ID]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
 }
 
 TEST_F(ChargepointTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZero_ThenProfileIsInvalid) {
-    auto wrong_evse_id = 0;
-    create_evse_with_id(0);
-    auto profile = create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+    auto wrong_evse_id = STATION_WIDE_ID;
+    create_evse_with_id(wrong_evse_id);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
     auto sut = handler.validate_tx_profile(profile, *evses[wrong_evse_id]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero));
 }
 
 TEST_F(ChargepointTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_ThenProfileIsInvalid) {
-    create_evse_with_id(evse_id);
-    open_evse_transaction(evse_id, "wrong transaction id");
-    auto profile = create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), uuid());
-    auto sut = handler.validate_tx_profile(profile, *evses[evse_id]);
+    create_evse_with_id(DEFAULT_EVSE_ID);
+    open_evse_transaction(DEFAULT_EVSE_ID, "wrong transaction id");
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+    auto sut = handler.validate_tx_profile(profile, *evses[DEFAULT_EVSE_ID]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileTransactionNotOnEvse));
 }
@@ -170,64 +183,112 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     auto meter_start = MeterValue();
     auto id_token = IdToken();
     auto date_time = ocpp::DateTime("2024-01-17T17:00:00");
-    create_evse_with_id(evse_id);
-    auto profile = create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), uuid());
-    auto sut = handler.validate_tx_profile(profile, *evses[evse_id]);
+    create_evse_with_id(DEFAULT_EVSE_ID);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+    auto sut = handler.validate_tx_profile(profile, *evses[DEFAULT_EVSE_ID]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
 
 TEST_F(ChargepointTestFixtureV201,
        K01FR06_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
-    create_evse_with_id(evse_id);
+    create_evse_with_id(DEFAULT_EVSE_ID);
     std::string transaction_id = uuid();
-    open_evse_transaction(evse_id, transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
 
     auto same_stack_level = 42;
     auto profile_1 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
     auto profile_2 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
-    handler.add_profile(profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+        create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    handler.add_profile(DEFAULT_EVSE_ID, profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
 }
 
 TEST_F(ChargepointTestFixtureV201,
        K01FR06_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
-    create_evse_with_id(evse_id);
+    create_evse_with_id(DEFAULT_EVSE_ID);
     std::string transaction_id = uuid();
     std::string different_transaction_id = uuid();
-    open_evse_transaction(evse_id, transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
 
     auto same_stack_level = 42;
     auto profile_1 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
-    auto profile_2 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id, same_stack_level);
-    handler.add_profile(profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
+                                             create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id,
+                                             same_stack_level);
+    handler.add_profile(DEFAULT_EVSE_ID, profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
 TEST_F(ChargepointTestFixtureV201,
        K01FR06_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
-    create_evse_with_id(evse_id);
+    create_evse_with_id(DEFAULT_EVSE_ID);
     std::string same_transaction_id = uuid();
-    open_evse_transaction(evse_id, same_transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, same_transaction_id);
 
     auto stack_level_1 = 42;
     auto stack_level_2 = 43;
+
     auto profile_1 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_1);
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_1);
     auto profile_2 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_2);
-    handler.add_profile(profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+        create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_2);
+
+    handler.add_profile(DEFAULT_EVSE_ID, profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+/*
+ * 0 - For K01.FR.52, we return DuplicateTxDefaultProfileFound if an existing profile is on an EVSE,
+ *  and a new profile with the same stack level and different profile ID will be associated with EVSE ID = 0.
+ * 1 - For K01.FR.53, we return DuplicateTxDefaultProfileFound if an existing profile is on an EVSE ID = 0,
+ *  and a new profile with the same stack level and different profile ID will be associated with an EVSE.
+ * 2-7 - We return Valid for any other case, such as using the same EVSE or using the same profile ID.
+ */
+
+INSTANTIATE_TEST_SUITE_P(
+    TxDefaultProfileValidationV201_Param_Test_Instantiate, ChargepointTestFixtureV201,
+    testing::Values(std::make_tuple(DEFAULT_EVSE_ID, STATION_WIDE_ID, DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL,
+                                    ProfileValidationResultEnum::DuplicateTxDefaultProfileFound),
+                    std::make_tuple(STATION_WIDE_ID, DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL,
+                                    ProfileValidationResultEnum::DuplicateTxDefaultProfileFound),
+                    std::make_tuple(STATION_WIDE_ID, STATION_WIDE_ID, DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL,
+                                    ProfileValidationResultEnum::Valid),
+                    std::make_tuple(DEFAULT_EVSE_ID, DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL,
+                                    ProfileValidationResultEnum::Valid),
+                    std::make_tuple(DEFAULT_EVSE_ID, STATION_WIDE_ID, DEFAULT_PROFILE_ID, DEFAULT_STACK_LEVEL,
+                                    ProfileValidationResultEnum::Valid),
+                    std::make_tuple(STATION_WIDE_ID, DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, DEFAULT_STACK_LEVEL,
+                                    ProfileValidationResultEnum::Valid),
+                    std::make_tuple(DEFAULT_EVSE_ID, STATION_WIDE_ID, DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL + 1,
+                                    ProfileValidationResultEnum::Valid),
+                    std::make_tuple(STATION_WIDE_ID, DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL + 1,
+                                    ProfileValidationResultEnum::Valid)));
+
+TEST_P(ChargepointTestFixtureV201, K01FR52_and_K01FR53_TxDefaultProfileValidationV201Tests) {
+    auto [existing_evse_id, added_evse_id, added_profile_id, added_stack_level, expected] = GetParam();
+    install_profile_on_evse(existing_evse_id, DEFAULT_PROFILE_ID);
+
+    create_evse_with_id(added_evse_id);
+    auto profile = create_charging_profile(added_profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(), added_stack_level);
+    auto sut = handler.validate_tx_default_profile(profile, *evses[added_evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(expected));
 }
 
 } // namespace ocpp::v201


### PR DESCRIPTION
Given a TxDefaultProfile on an EVSE or on the charging station as a whole, we can validate whether a new TxDefaultProfile is allowed.