### PR TITLE
Add TxDefaultProfile to either EVSE or entire station.

### DIFF
--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -5,6 +5,7 @@
 #define OCPP_V201_SMART_CHARGING_HPP
 
 #include "ocpp/v201/enums.hpp"
+#include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include <limits>
 
 #include <ocpp/v201/database_handler.hpp>
@@ -81,7 +82,7 @@ public:
     ///
     /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
     ///
-    ProfileValidationResultEnum add_profile(int32_t evse_id, ChargingProfile& profile);
+    SetChargingProfileResponse add_profile(int32_t evse_id, ChargingProfile& profile);
 
     ///
     /// \brief Retrieves existing profiles on system.

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -81,7 +81,12 @@ public:
     ///
     /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
     ///
-    void add_profile(int32_t evse_id, ChargingProfile& profile);
+    ProfileValidationResultEnum add_profile(int32_t evse_id, ChargingProfile& profile);
+
+    ///
+    /// \brief Retrieves existing profiles on system.
+    ///
+    std::vector<ChargingProfile> get_profiles();
 
 private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -192,14 +192,15 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
     return ProfileValidationResultEnum::Valid;
 }
 
-ProfileValidationResultEnum SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
+SetChargingProfileResponse SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
     if (STATION_WIDE_ID == evse_id) {
         station_wide_charging_profiles.push_back(profile);
     } else {
         charging_profiles[evse_id].push_back(profile);
     }
-
-    return ProfileValidationResultEnum::Valid;
+    SetChargingProfileResponse response;
+    response.status = ChargingProfileStatusEnum::Accepted;
+    return response;
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_profiles() {

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -192,12 +192,22 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
     return ProfileValidationResultEnum::Valid;
 }
 
-void SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
+ProfileValidationResultEnum SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
     if (STATION_WIDE_ID == evse_id) {
         station_wide_charging_profiles.push_back(profile);
     } else {
         charging_profiles[evse_id].push_back(profile);
     }
+
+    return ProfileValidationResultEnum::Valid;
+}
+
+std::vector<ChargingProfile> SmartChargingHandler::get_profiles() {
+    auto all_profiles = station_wide_charging_profiles;
+    for (auto evse_profile_pair : charging_profiles) {
+        all_profiles.insert(all_profiles.end(), evse_profile_pair.second.begin(), evse_profile_pair.second.end());
+    }
+    return all_profiles;
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_evse_specific_tx_default_profiles() const {

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -560,7 +560,7 @@ TEST_F(ChargepointTestFixtureV201,
 
     auto sut = handler.add_profile(STATION_WIDE_ID, profile);
 
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+    EXPECT_THAT(sut.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
     EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
 }
 
@@ -573,7 +573,7 @@ TEST_F(ChargepointTestFixtureV201,
 
     auto sut = handler.add_profile(DEFAULT_EVSE_ID, profile);
 
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+    EXPECT_THAT(sut.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
     EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
 }
 


### PR DESCRIPTION
## Describe your changes

I added some tests for adding a TxDefaultProfile either to the entire station or to a specific EVSE.

Validation is presumed, and eventually validation will be included in add_profile(), but not for this user story.

## Issue ticket number and link

https://github.com/US-JOET/base-camp/issues/98

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

