### PR TITLE
Adding 2.0 validate ChargingStationMaxProfile

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1172,7 +1172,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.35 |  |  |
 | K01.FR.36 | :white_check_mark: |  |
 | K01.FR.37 |  |  |
-| K01.FR.38 |  |  |
+| K01.FR.38 | :white_check_mark: |  |
 | K01.FR.39 | :white_check_mark: |  |
 | K01.FR.40 | :white_check_mark: |  |
 | K01.FR.41 | :white_check_mark: |  |
@@ -1218,7 +1218,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | --- | --- | --- |
 | K04.FR.01 |  |  |
 | K04.FR.02 |  |  |
-| K04.FR.03 |  |  |
+| K04.FR.03 | :white_check_mark: |  |
 | K04.FR.04 |  |  |
 | K04.FR.05 |  |  |
 ## SmartCharging - Remote Start Transaction with Charging Profile

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -71,7 +71,7 @@ public:
     /// according to the specification
     ///
     ProfileValidationResultEnum validate_charging_station_max_profile(const ChargingProfile& profile,
-                                                                      EvseInterface& evse) const;
+                                                                      int32_t evse_id) const;
 
     ///
     /// \brief validates the given \p profile and associated \p evse_id according to the specification

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -19,6 +19,7 @@ const int DEFAULT_AND_MAX_NUMBER_PHASES = 3;
 enum class ProfileValidationResultEnum {
     Valid,
     EvseDoesNotExist,
+    InvalidProfileType,
     TxProfileMissingTransactionId,
     TxProfileEvseIdNotGreaterThanZero,
     TxProfileTransactionNotOnEvse,
@@ -32,6 +33,8 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodInvalidPhaseToUse,
     ChargingSchedulePeriodUnsupportedNumberPhases,
     ChargingSchedulePeriodExtraneousPhaseValues,
+    ChargingStationMaxProfileCannotBeRelative,
+    ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,
     DuplicateProfileValidityPeriod
 };
@@ -62,6 +65,13 @@ public:
     /// \brief validates the existence of the given \p evse_id according to the specification
     ///
     ProfileValidationResultEnum validate_evse_exists(int32_t evse_id) const;
+
+    ///
+    /// \brief validates requirements that apply only to the ChargingStationMaxProfile \p profile
+    /// according to the specification
+    ///
+    ProfileValidationResultEnum validate_charging_station_max_profile(const ChargingProfile& profile,
+                                                                      EvseInterface& evse) const;
 
     ///
     /// \brief validates the given \p profile and associated \p evse_id according to the specification

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -24,6 +24,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "Valid";
     case ProfileValidationResultEnum::EvseDoesNotExist:
         return "EvseDoesNotExist";
+    case ProfileValidationResultEnum::InvalidProfileType:
+        return "InvalidProfileType";
     case ProfileValidationResultEnum::TxProfileMissingTransactionId:
         return "TxProfileMissingTransactionId";
     case ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero:
@@ -50,6 +52,10 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodUnsupportedNumberPhases";
     case ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues:
         return "ChargingSchedulePeriodExtraneousPhaseValues";
+    case ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative:
+        return "ChargingStationMaxProfileCannotBeRelative";
+    case ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero:
+        return "ChargingStationMaxProfileEvseIdGreaterThanZero";
     case ProfileValidationResultEnum::DuplicateTxDefaultProfileFound:
         return "DuplicateTxDefaultProfileFound";
     }

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -74,13 +74,12 @@ ProfileValidationResultEnum SmartChargingHandler::validate_evse_exists(int32_t e
 }
 
 ProfileValidationResultEnum SmartChargingHandler::validate_charging_station_max_profile(const ChargingProfile& profile,
-                                                                                        EvseInterface& evse) const {
+                                                                                        int32_t evse_id) const {
     if (profile.chargingProfilePurpose != ChargingProfilePurposeEnum::ChargingStationMaxProfile) {
         return ProfileValidationResultEnum::InvalidProfileType;
     }
 
-    int32_t evseId = evse.get_evse_info().id;
-    if (evseId > 0) {
+    if (evse_id > 0) {
         return ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero;
     }
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -73,6 +73,24 @@ ProfileValidationResultEnum SmartChargingHandler::validate_evse_exists(int32_t e
                                               : ProfileValidationResultEnum::Valid;
 }
 
+ProfileValidationResultEnum SmartChargingHandler::validate_charging_station_max_profile(const ChargingProfile& profile,
+                                                                                        EvseInterface& evse) const {
+    if (profile.chargingProfilePurpose != ChargingProfilePurposeEnum::ChargingStationMaxProfile) {
+        return ProfileValidationResultEnum::InvalidProfileType;
+    }
+
+    int32_t evseId = evse.get_evse_info().id;
+    if (evseId > 0) {
+        return ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero;
+    }
+
+    if (profile.chargingProfileKind == ChargingProfileKindEnum::Relative) {
+        return ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative;
+    }
+
+    return ProfileValidationResultEnum::Valid;
+}
+
 ProfileValidationResultEnum SmartChargingHandler::validate_tx_default_profile(ChargingProfile& profile,
                                                                               int32_t evse_id) const {
     auto profiles = evse_id == 0 ? get_evse_specific_tx_default_profiles() : get_station_wide_tx_default_profiles();

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -292,6 +292,70 @@ TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChon
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder));
 }
 
+TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChargingStationMaxProfile_Invalid) {
+    create_evse_with_id(STATION_WIDE_ID);
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+
+    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::InvalidProfileType));
+}
+
+TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_EvseIDgt0_Invalid) {
+    const int EVSE_ID_1 = DEFAULT_EVSE_ID;
+    create_evse_with_id(EVSE_ID_1);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(EVSE_ID_1, same_transaction_id);
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A, periods), same_transaction_id);
+
+    auto sut = handler.validate_charging_station_max_profile(profile, *evses[EVSE_ID_1]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsAbsolute_Valid) {
+    create_evse_with_id(STATION_WIDE_ID);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(STATION_WIDE_ID, same_transaction_id);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id);
+
+    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRecurring_Valid) {
+    create_evse_with_id(STATION_WIDE_ID);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(STATION_WIDE_ID, same_transaction_id);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
+                                           ChargingProfileKindEnum::Recurring);
+
+    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRelative_Invalid) {
+    create_evse_with_id(STATION_WIDE_ID);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(STATION_WIDE_ID, same_transaction_id);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
+                                           ChargingProfileKindEnum::Relative);
+
+    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative));
+}
+
 TEST_F(ChargepointTestFixtureV201,
        K01FR39_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -298,7 +298,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChar
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid());
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::InvalidProfileType));
 }
@@ -313,7 +313,7 @@ TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_Evs
         create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                 create_charge_schedule(ChargingRateUnitEnum::A, periods), same_transaction_id);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[EVSE_ID_1]);
+    auto sut = handler.validate_charging_station_max_profile(profile, EVSE_ID_1);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero));
 }
@@ -325,7 +325,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -338,7 +338,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
                                            create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
                                            ChargingProfileKindEnum::Recurring);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -351,7 +351,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
                                            create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
                                            ChargingProfileKindEnum::Relative);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative));
 }


### PR DESCRIPTION
## Describe your changes

Handles K01.FR.38 and K04.FR.03 from the OCPP 2.0.1 specification. 

> K01.FR.38: When chargingProfilePurpose = ChargingStationMaxProfilechargingProfileKind SHALL NOT be Relative
> 
> K04.FR.03: The optional ChargingSchedule field minChargingRate MAY be used by the Charging Station to optimize the power distribution between the EVSEs.

## Issue ticket number and link

[K01 - Charging Station Max Profile Validation #99](https://github.com/US-JOET/base-camp/issues/99)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

