### PR TITLE
smart_charging: Handle profile updates per K01.FR.05

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1143,7 +1143,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.02 |  |  |
 | K01.FR.03 |  |  |
 | K01.FR.04 | :white_check_mark: |  |
-| K01.FR.05 |  |  |
+| K01.FR.05 | :white_check_mark: |  |
 | K01.FR.06 |  |  |
 | K01.FR.07 |  |  |
 | K01.FR.08 |  |  |

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -5,6 +5,7 @@
 #include "ocpp/common/types.hpp"
 #include "ocpp/v201/enums.hpp"
 #include "ocpp/v201/evse.hpp"
+#include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include "ocpp/v201/ocpp_types.hpp"
 #include "ocpp/v201/transaction.hpp"
 #include <iterator>
@@ -193,13 +194,21 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
 }
 
 SetChargingProfileResponse SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
-    if (STATION_WIDE_ID == evse_id) {
-        station_wide_charging_profiles.push_back(profile);
-    } else {
-        charging_profiles[evse_id].push_back(profile);
-    }
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatusEnum::Accepted;
+
+    auto& profile_storage = (STATION_WIDE_ID == evse_id) ? station_wide_charging_profiles : charging_profiles[evse_id];
+    auto profile_with_id =
+        std::find_if(profile_storage.begin(), profile_storage.end(),
+                     [&profile](const ChargingProfile existing_profile) { return profile.id == existing_profile.id; });
+
+    if (profile_with_id != profile_storage.end() &&
+        profile_with_id->chargingProfilePurpose != ChargingProfilePurposeEnum::ChargingStationExternalConstraints) {
+        *profile_with_id = profile;
+    } else {
+        profile_storage.push_back(profile);
+    }
+
     return response;
 }
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -577,4 +577,49 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
 }
 
+TEST_F(ChargepointTestFixtureV201,
+       K01FR05_IfProfileWithSameIdExistsAndIsNotChargingStationExternalContraints_ThenProfileIsReplaced) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+    auto profile2 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+
+    auto sut1 = handler.add_profile(DEFAULT_EVSE_ID, profile1);
+    auto sut2 = handler.add_profile(DEFAULT_EVSE_ID, profile2);
+
+    auto profiles = handler.get_profiles();
+
+    EXPECT_THAT(sut1.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(sut2.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(profiles, testing::Contains(profile2));
+    EXPECT_THAT(profiles, testing::Not(testing::Contains(profile1)));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR05_IfProfileWithSameIdExistsAndIsChargingStationExternalContraints_ThenProfileIsAppended) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    auto profile1 =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationExternalConstraints,
+                                create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+    auto profile2 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+
+    auto sut1 = handler.add_profile(DEFAULT_EVSE_ID, profile1);
+    auto sut2 = handler.add_profile(DEFAULT_EVSE_ID, profile2);
+
+    auto profiles = handler.get_profiles();
+
+    EXPECT_THAT(sut1.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(sut2.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(profiles, testing::Contains(profile1));
+    EXPECT_THAT(profiles, testing::Contains(profile2));
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

Handles K01.FR.05. There are two open questions on this one:

* The spec doesn't specify whether or not it's valid to have a profile with the same id when one with a `ChargingStationExternalConstraints` already exists - just that `ChargingStationExternalConstraints` profiles can't be replaced. For this PR currently I assume it is, since the purpose is different and the main thing to avoid is having profiles with the same `stackLevel` and `purpose` at the same time.
* When the spec says to replace the profile, it doesn't make sense (to me) to replace a station-wide profile with an evse-specific profile. That said, the spec doesn't clarify that detail.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

