### PR TITLE
Check boxes for K01.FR.14 and K01.FR.15.

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1152,8 +1152,8 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.11 |  |  |
 | K01.FR.12 |  |  |
 | K01.FR.13 |  |  |
-| K01.FR.14 |  |  |
-| K01.FR.15 |  |  |
+| K01.FR.14 | :white_check_mark: |  |
+| K01.FR.15 | :white_check_mark: |  |
 | K01.FR.16 |  |  |
 | K01.FR.17 |  |  |
 | K01.FR.19 |  |  |


### PR DESCRIPTION

I added some tests for adding a TxDefaultProfile either to the entire station or to a specific EVSE.

Validation is presumed, and eventually validation will be included in add_profile(), but not for this user story.

