### PR TITLE
K01 - implement and test set charging profiles callback

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1140,7 +1140,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | ID | Status | Remark |
 | --- | --- | --- |
 | K01.FR.01 |  |  |
-| K01.FR.02 |  |  |
+| K01.FR.02 | :white_check_mark: |  |
 | K01.FR.03 |  |  |
 | K01.FR.04 | :white_check_mark: |  |
 | K01.FR.05 | :white_check_mark: |  |

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -67,7 +67,7 @@ class UnexpectedMessageTypeFromCSMS : public std::runtime_error {
 
 struct Callbacks {
     ///\brief Function to check if the callback struct is completely filled. All std::functions should hold a function,
-    ///       all std::optional<std::functions> should either be emtpy or hold a function.
+    ///       all std::optional<std::functions> should either be empty or hold a function.
     ///
     ///\retval false if any of the normal callbacks are nullptr or any of the optional ones are filled with a nullptr
     ///        true otherwise

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -144,6 +144,9 @@ struct Callbacks {
     std::function<void(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info)>
         security_event_callback;
 
+    /// \brief Callback for indicating when a charging profile is received and was accepted.
+    std::function<void()> set_charging_profiles_callback;
+
     /// \brief  Callback for when a bootnotification response is received
     std::optional<std::function<void(const ocpp::v201::RegistrationStatusEnum& reg_status)>> boot_notification_callback;
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -32,6 +32,7 @@ bool Callbacks::all_callbacks_valid() const {
            this->get_log_request_callback != nullptr and this->unlock_connector_callback != nullptr and
            this->remote_start_transaction_callback != nullptr and this->is_reservation_for_token_callback != nullptr and
            this->update_firmware_request_callback != nullptr and
+           this->security_event_callback != nullptr and
            (!this->variable_changed_callback.has_value() or this->variable_changed_callback.value() != nullptr) and
            (!this->validate_network_profile_callback.has_value() or
             this->validate_network_profile_callback.value() != nullptr) and

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -40,7 +40,21 @@ bool Callbacks::all_callbacks_valid() const {
             this->configure_network_connection_profile_callback.value() != nullptr) and
            (!this->time_sync_callback.has_value() or this->time_sync_callback.value() != nullptr) and
            (!this->boot_notification_callback.has_value() or this->boot_notification_callback.value() != nullptr) and
-           (!this->ocpp_messages_callback.has_value() or this->ocpp_messages_callback.value() != nullptr);
+           (!this->ocpp_messages_callback.has_value() or this->ocpp_messages_callback.value() != nullptr) and
+           (!this->cs_effective_operative_status_changed_callback.has_value() or
+            this->cs_effective_operative_status_changed_callback.value() != nullptr) and
+           (!this->evse_effective_operative_status_changed_callback.has_value() or
+            this->evse_effective_operative_status_changed_callback.value() != nullptr) and
+           (!this->get_customer_information_callback.has_value() or
+            this->get_customer_information_callback.value() != nullptr) and
+           (!this->clear_customer_information_callback.has_value() or
+            this->clear_customer_information_callback.value() != nullptr) and
+           (!this->all_connectors_unavailable_callback.has_value() or
+            this->all_connectors_unavailable_callback.value() != nullptr) and
+           (!this->data_transfer_callback.has_value() or this->data_transfer_callback.value() != nullptr) and
+           (!this->transaction_event_callback.has_value() or this->transaction_event_callback.value() != nullptr) and
+           (!this->transaction_event_response_callback.has_value() or
+            this->transaction_event_response_callback.value() != nullptr);
 }
 
 ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -33,6 +33,7 @@ bool Callbacks::all_callbacks_valid() const {
            this->remote_start_transaction_callback != nullptr and this->is_reservation_for_token_callback != nullptr and
            this->update_firmware_request_callback != nullptr and
            this->security_event_callback != nullptr and
+           this->set_charging_profiles_callback != nullptr and
            (!this->variable_changed_callback.has_value() or this->variable_changed_callback.value() != nullptr) and
            (!this->validate_network_profile_callback.has_value() or
             this->validate_network_profile_callback.value() != nullptr) and

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -31,8 +31,7 @@ bool Callbacks::all_callbacks_valid() const {
            this->connector_effective_operative_status_changed_callback != nullptr and
            this->get_log_request_callback != nullptr and this->unlock_connector_callback != nullptr and
            this->remote_start_transaction_callback != nullptr and this->is_reservation_for_token_callback != nullptr and
-           this->update_firmware_request_callback != nullptr and
-           this->security_event_callback != nullptr and
+           this->update_firmware_request_callback != nullptr and this->security_event_callback != nullptr and
            this->set_charging_profiles_callback != nullptr and
            (!this->variable_changed_callback.has_value() or this->variable_changed_callback.value() != nullptr) and
            (!this->validate_network_profile_callback.has_value() or

--- a/tests/lib/ocpp/v201/CMakeLists.txt
+++ b/tests/lib/ocpp/v201/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_include_directories(libocpp_unit_tests PUBLIC mocks)
 
 target_sources(libocpp_unit_tests PRIVATE
+        test_charge_point.cpp
         test_database_migration_files.cpp
         test_device_model_storage_sqlite.cpp
         test_notify_report_requests_splitter.cpp

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -1,0 +1,35 @@
+#include "ocpp/v201/charge_point.hpp"
+#include "gmock/gmock.h"
+#include <gmock/gmock.h>
+
+namespace ocpp::v201 {
+
+TEST(ChargePointFixture, CallbacksAreValidWhenAllRequiredCallbacksProvided) {
+    ocpp::v201::Callbacks callbacks;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)> is_reset_allowed_callback_mock;
+    testing::MockFunction<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)> reset_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id, const ReasonEnum& stop_reason)> stop_transaction_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id)> pause_charging_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id, const int32_t connector_id, const OperationalStatusEnum new_status)> connector_effective_operative_status_changed_callback_mock;
+    testing::MockFunction<GetLogResponse(const GetLogRequest& request)> get_log_request_callback_mock;
+    testing::MockFunction<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)> unlock_connector_callback_mock;
+    testing::MockFunction<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)> remote_start_transaction_callback_mock;
+    testing::MockFunction<bool(const int32_t evse_id, const CiString<36> idToken, const std::optional<CiString<36>> groupIdToken)> is_reservation_for_token_callback_mock;
+    testing::MockFunction<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)> update_firmware_request_callback_mock;
+
+    callbacks.is_reset_allowed_callback = is_reset_allowed_callback_mock.AsStdFunction();
+    callbacks.reset_callback = reset_callback_mock.AsStdFunction();
+    callbacks.stop_transaction_callback = stop_transaction_callback_mock.AsStdFunction();
+    callbacks.pause_charging_callback = pause_charging_callback_mock.AsStdFunction();
+    callbacks.connector_effective_operative_status_changed_callback = connector_effective_operative_status_changed_callback_mock.AsStdFunction();
+    callbacks.get_log_request_callback = get_log_request_callback_mock.AsStdFunction();
+    callbacks.unlock_connector_callback = unlock_connector_callback_mock.AsStdFunction();
+    callbacks.remote_start_transaction_callback = remote_start_transaction_callback_mock.AsStdFunction();
+    callbacks.is_reservation_for_token_callback = is_reservation_for_token_callback_mock.AsStdFunction();
+    callbacks.update_firmware_request_callback = update_firmware_request_callback_mock.AsStdFunction();
+
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+}

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -24,6 +24,7 @@ public:
         callbacks.is_reservation_for_token_callback = is_reservation_for_token_callback_mock.AsStdFunction();
         callbacks.update_firmware_request_callback = update_firmware_request_callback_mock.AsStdFunction();
         callbacks.security_event_callback = security_event_callback_mock.AsStdFunction();
+        callbacks.set_charging_profiles_callback = set_charging_profiles_callback_mock.AsStdFunction();
     }
 
     testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
@@ -47,6 +48,7 @@ public:
         update_firmware_request_callback_mock;
     testing::MockFunction<void(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info)>
         security_event_callback_mock;
+    testing::MockFunction<void()> set_charging_profiles_callback_mock;
     ocpp::v201::Callbacks callbacks;
 };
 
@@ -135,5 +137,14 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfSecurityEventCallbackExists)
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.set_charging_profiles_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -145,4 +145,71 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfSetChargingProfilesCallbackE
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.variable_changed_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const SetVariableData& set_variable_data)> variable_changed_callback_mock;
+    callbacks.variable_changed_callback = variable_changed_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.validate_network_profile_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<SetNetworkProfileStatusEnum(
+        const int32_t configuration_slot, const NetworkConnectionProfile& network_connection_profile)> validate_network_profile_callback_mock;
+    callbacks.validate_network_profile_callback = validate_network_profile_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.configure_network_connection_profile_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<bool(const NetworkConnectionProfile& network_connection_profile)> configure_network_connection_profile_callback_mock;
+    callbacks.configure_network_connection_profile_callback = configure_network_connection_profile_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.time_sync_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const ocpp::DateTime& currentTime)> time_sync_callback_mock;
+    callbacks.time_sync_callback = time_sync_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.boot_notification_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const ocpp::v201::RegistrationStatusEnum& reg_status)> boot_notification_callback_mock;
+    callbacks.boot_notification_callback = boot_notification_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.ocpp_messages_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const std::string& message, MessageDirection direction)> ocpp_messages_callback_mock;
+    callbacks.ocpp_messages_callback = ocpp_messages_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -216,4 +216,106 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalOCPPMessages
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
+TEST_F(ChargePointFixture,
+       K01FR02_CallbacksValidityChecksIfOptionalCSEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.cs_effective_operative_status_changed_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const OperationalStatusEnum new_status)>
+        cs_effective_operative_status_changed_callback_mock;
+    callbacks.cs_effective_operative_status_changed_callback =
+        cs_effective_operative_status_changed_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture,
+       K01FR02_CallbacksValidityChecksIfOptionalEvseEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.evse_effective_operative_status_changed_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const int32_t evse_id, const OperationalStatusEnum new_status)>
+        evse_effective_operative_status_changed_callback_mock;
+    callbacks.evse_effective_operative_status_changed_callback =
+        evse_effective_operative_status_changed_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalGetCustomerInformationCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.get_customer_information_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<std::string(const std::optional<CertificateHashDataType> customer_certificate,
+                                      const std::optional<IdToken> id_token,
+                                      const std::optional<CiString<64>> customer_identifier)>
+        get_customer_information_callback_mock;
+    callbacks.get_customer_information_callback = get_customer_information_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalClearCustomerInformationCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.clear_customer_information_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<std::string(const std::optional<CertificateHashDataType> customer_certificate,
+                                      const std::optional<IdToken> id_token,
+                                      const std::optional<CiString<64>> customer_identifier)>
+        clear_customer_information_callback_mock;
+    callbacks.clear_customer_information_callback = clear_customer_information_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalAllConnectorsUnavailableCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.all_connectors_unavailable_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void()> all_connectors_unavailable_callback_mock;
+    callbacks.all_connectors_unavailable_callback = all_connectors_unavailable_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalDataTransferCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.data_transfer_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<DataTransferResponse(const DataTransferRequest& request)> data_transfer_callback_mock;
+    callbacks.data_transfer_callback = data_transfer_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.transaction_event_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const TransactionEventRequest& transaction_event)> transaction_event_callback_mock;
+    callbacks.transaction_event_callback = transaction_event_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventResponseCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.transaction_event_response_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const TransactionEventRequest& transaction_event,
+                               const TransactionEventResponse& transaction_event_response)>
+        transaction_event_response_callback_mock;
+    callbacks.transaction_event_response_callback = transaction_event_response_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -23,6 +23,7 @@ public:
         callbacks.remote_start_transaction_callback = remote_start_transaction_callback_mock.AsStdFunction();
         callbacks.is_reservation_for_token_callback = is_reservation_for_token_callback_mock.AsStdFunction();
         callbacks.update_firmware_request_callback = update_firmware_request_callback_mock.AsStdFunction();
+        callbacks.security_event_callback = security_event_callback_mock.AsStdFunction();
     }
 
     testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
@@ -44,6 +45,8 @@ public:
         is_reservation_for_token_callback_mock;
     testing::MockFunction<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)>
         update_firmware_request_callback_mock;
+    testing::MockFunction<void(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info)>
+        security_event_callback_mock;
     ocpp::v201::Callbacks callbacks;
 };
 
@@ -122,6 +125,13 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfIsReservationForTokenCallbac
 TEST_F(ChargePointFixture, CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.update_firmware_request_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfSecurityEventCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.security_event_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -145,6 +145,4 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfSetChargingProfilesCallbackE
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-
-
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -4,32 +4,126 @@
 
 namespace ocpp::v201 {
 
-TEST(ChargePointFixture, CallbacksAreValidWhenAllRequiredCallbacksProvided) {
-    ocpp::v201::Callbacks callbacks;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
+class ChargePointFixture : public testing::Test {
+public:
+    ChargePointFixture() {
+    }
+    ~ChargePointFixture() {
+    }
 
-    testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)> is_reset_allowed_callback_mock;
-    testing::MockFunction<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)> reset_callback_mock;
+    void configure_callbacks_with_mocks() {
+        callbacks.is_reset_allowed_callback = is_reset_allowed_callback_mock.AsStdFunction();
+        callbacks.reset_callback = reset_callback_mock.AsStdFunction();
+        callbacks.stop_transaction_callback = stop_transaction_callback_mock.AsStdFunction();
+        callbacks.pause_charging_callback = pause_charging_callback_mock.AsStdFunction();
+        callbacks.connector_effective_operative_status_changed_callback =
+            connector_effective_operative_status_changed_callback_mock.AsStdFunction();
+        callbacks.get_log_request_callback = get_log_request_callback_mock.AsStdFunction();
+        callbacks.unlock_connector_callback = unlock_connector_callback_mock.AsStdFunction();
+        callbacks.remote_start_transaction_callback = remote_start_transaction_callback_mock.AsStdFunction();
+        callbacks.is_reservation_for_token_callback = is_reservation_for_token_callback_mock.AsStdFunction();
+        callbacks.update_firmware_request_callback = update_firmware_request_callback_mock.AsStdFunction();
+    }
+
+    testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
+        is_reset_allowed_callback_mock;
+    testing::MockFunction<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
+        reset_callback_mock;
     testing::MockFunction<void(const int32_t evse_id, const ReasonEnum& stop_reason)> stop_transaction_callback_mock;
     testing::MockFunction<void(const int32_t evse_id)> pause_charging_callback_mock;
-    testing::MockFunction<void(const int32_t evse_id, const int32_t connector_id, const OperationalStatusEnum new_status)> connector_effective_operative_status_changed_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id, const int32_t connector_id,
+                               const OperationalStatusEnum new_status)>
+        connector_effective_operative_status_changed_callback_mock;
     testing::MockFunction<GetLogResponse(const GetLogRequest& request)> get_log_request_callback_mock;
-    testing::MockFunction<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)> unlock_connector_callback_mock;
-    testing::MockFunction<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)> remote_start_transaction_callback_mock;
-    testing::MockFunction<bool(const int32_t evse_id, const CiString<36> idToken, const std::optional<CiString<36>> groupIdToken)> is_reservation_for_token_callback_mock;
-    testing::MockFunction<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)> update_firmware_request_callback_mock;
+    testing::MockFunction<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)>
+        unlock_connector_callback_mock;
+    testing::MockFunction<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)>
+        remote_start_transaction_callback_mock;
+    testing::MockFunction<bool(const int32_t evse_id, const CiString<36> idToken,
+                               const std::optional<CiString<36>> groupIdToken)>
+        is_reservation_for_token_callback_mock;
+    testing::MockFunction<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)>
+        update_firmware_request_callback_mock;
+    ocpp::v201::Callbacks callbacks;
+};
 
-    callbacks.is_reset_allowed_callback = is_reset_allowed_callback_mock.AsStdFunction();
-    callbacks.reset_callback = reset_callback_mock.AsStdFunction();
-    callbacks.stop_transaction_callback = stop_transaction_callback_mock.AsStdFunction();
-    callbacks.pause_charging_callback = pause_charging_callback_mock.AsStdFunction();
-    callbacks.connector_effective_operative_status_changed_callback = connector_effective_operative_status_changed_callback_mock.AsStdFunction();
-    callbacks.get_log_request_callback = get_log_request_callback_mock.AsStdFunction();
-    callbacks.unlock_connector_callback = unlock_connector_callback_mock.AsStdFunction();
-    callbacks.remote_start_transaction_callback = remote_start_transaction_callback_mock.AsStdFunction();
-    callbacks.is_reservation_for_token_callback = is_reservation_for_token_callback_mock.AsStdFunction();
-    callbacks.update_firmware_request_callback = update_firmware_request_callback_mock.AsStdFunction();
+TEST_F(ChargePointFixture, CallbacksAreInvalidWhenNotProvided) {
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
 
+TEST_F(ChargePointFixture, CallbacksAreValidWhenAllRequiredCallbacksProvided) {
+    configure_callbacks_with_mocks();
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.is_reset_allowed_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfResetCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.reset_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfStopTransactionCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.stop_transaction_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfPauseChargingCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.pause_charging_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.connector_effective_operative_status_changed_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfGetLogRequestCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.get_log_request_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.unlock_connector_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.remote_start_transaction_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.is_reservation_for_token_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointFixture, CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.update_firmware_request_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -162,20 +162,24 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableNetworkProfi
     callbacks.validate_network_profile_callback = nullptr;
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 
-    testing::MockFunction<SetNetworkProfileStatusEnum(
-        const int32_t configuration_slot, const NetworkConnectionProfile& network_connection_profile)> validate_network_profile_callback_mock;
+    testing::MockFunction<SetNetworkProfileStatusEnum(const int32_t configuration_slot,
+                                                      const NetworkConnectionProfile& network_connection_profile)>
+        validate_network_profile_callback_mock;
     callbacks.validate_network_profile_callback = validate_network_profile_callback_mock.AsStdFunction();
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
+TEST_F(ChargePointFixture,
+       CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.configure_network_connection_profile_callback = nullptr;
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 
-    testing::MockFunction<bool(const NetworkConnectionProfile& network_connection_profile)> configure_network_connection_profile_callback_mock;
-    callbacks.configure_network_connection_profile_callback = configure_network_connection_profile_callback_mock.AsStdFunction();
+    testing::MockFunction<bool(const NetworkConnectionProfile& network_connection_profile)>
+        configure_network_connection_profile_callback_mock;
+    callbacks.configure_network_connection_profile_callback =
+        configure_network_connection_profile_callback_mock.AsStdFunction();
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -52,100 +52,100 @@ public:
     ocpp::v201::Callbacks callbacks;
 };
 
-TEST_F(ChargePointFixture, CallbacksAreInvalidWhenNotProvided) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksAreInvalidWhenNotProvided) {
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksAreValidWhenAllRequiredCallbacksProvided) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksAreValidWhenAllRequiredCallbacksProvided) {
     configure_callbacks_with_mocks();
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.is_reset_allowed_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfResetCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfResetCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.reset_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfStopTransactionCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfStopTransactionCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.stop_transaction_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfPauseChargingCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfPauseChargingCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.pause_charging_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.connector_effective_operative_status_changed_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfGetLogRequestCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfGetLogRequestCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.get_log_request_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.unlock_connector_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.remote_start_transaction_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.is_reservation_for_token_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.update_firmware_request_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfSecurityEventCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSecurityEventCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.security_event_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.set_charging_profiles_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.variable_changed_callback = nullptr;
@@ -156,7 +156,7 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableChangedCallb
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.validate_network_profile_callback = nullptr;
@@ -170,7 +170,7 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalVariableNetworkProfi
 }
 
 TEST_F(ChargePointFixture,
-       CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
+       K01FR02_CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.configure_network_connection_profile_callback = nullptr;
@@ -183,7 +183,7 @@ TEST_F(ChargePointFixture,
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.time_sync_callback = nullptr;
@@ -194,7 +194,7 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNo
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.boot_notification_callback = nullptr;
@@ -205,7 +205,7 @@ TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalBootNotificationCall
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
+TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.ocpp_messages_callback = nullptr;


### PR DESCRIPTION
## Describe your changes

Added tests to cover the callbacks, including ensuring that a callback that wasn't being checked for validity now is checked for validity, and adding the new set_charging_profiles_callback.

## Issue ticket number and link
https://github.com/US-JOET/base-camp/issues/103

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

