### PR TITLE
charge_point: Fix incorrect type in tests

### DIFF
--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -200,7 +200,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalBootNotifica
     callbacks.boot_notification_callback = nullptr;
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 
-    testing::MockFunction<void(const ocpp::v201::RegistrationStatusEnum& reg_status)> boot_notification_callback_mock;
+    testing::MockFunction<void(const ocpp::v201::BootNotificationResponse& response)> boot_notification_callback_mock;
     callbacks.boot_notification_callback = boot_notification_callback_mock.AsStdFunction();
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }


### PR DESCRIPTION
## Describe your changes

Fixes a build issue with the add profile branch. An incorrect type caused the tests to fail to compile.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

