### PR TITLE
Added OCPP 2.0.1 Calculate Composite Schedule functionality and tests.

### DIFF
--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -17,7 +17,16 @@
 
 namespace ocpp::v201 {
 
+const int LOW_VOLTAGE = 230;
 const int DEFAULT_AND_MAX_NUMBER_PHASES = 3;
+const int HOURS_PER_DAY = 24;
+const int SECONDS_PER_HOUR = 3600;
+const int SECONDS_PER_DAY = 86400;
+const int DAYS_PER_WEEK = 7;
+
+const ocpp::DateTime MAX_DATE_TIME =
+    ocpp::DateTime(date::utc_clock::now() + std::chrono::hours(std::numeric_limits<int>::max()));
+const int MAX_PERIOD_LIMIT = std::numeric_limits<int>::max();
 
 enum class ProfileValidationResultEnum {
     Valid,
@@ -52,6 +61,18 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e);
 
 std::ostream& operator<<(std::ostream& os, const ProfileValidationResultEnum validation_result);
 
+/// \brief Helper struct to calculate Composite Schedule
+struct LimitStackLevelPair {
+    int limit;
+    int stack_level;
+};
+
+/// \brief Helper struct to calculate Composite Schedule
+struct PeriodDateTimePair {
+    std::optional<ChargingSchedulePeriod> period;
+    ocpp::DateTime end_time;
+};
+
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
 /// to calculate the composite schedules
 class SmartChargingHandler {
@@ -84,6 +105,13 @@ public:
     /// \brief Retrieves existing profiles on system.
     ///
     std::vector<ChargingProfile> get_profiles();
+
+    ///
+    /// \brief Calculates the composite schedule for the given \p valid_profiles and the given \p connector_id
+    ///
+    CompositeSchedule calculate_composite_schedule(std::vector<ChargingProfile> valid_profiles,
+                                                   const ocpp::DateTime& start_time, const ocpp::DateTime& end_time,
+                                                   const int32_t evse_id, ChargingRateUnitEnum charging_rate_unit);
 
 protected:
     ///
@@ -120,11 +148,48 @@ protected:
     ///
     bool is_overlapping_validity_period(int evse_id, const ChargingProfile& profile) const;
 
+    ///
+    /// \brief Iterates over the periods of the given \p profile and returns a struct that contains the period and the
+    /// absolute end time of the period that refers to the given absoulte \p time as a pair.
+    ///
+    PeriodDateTimePair find_period_at(const ocpp::DateTime& time, const ChargingProfile& profile, const int evse);
+
+    ///
+    /// \brief Gets the absolute start time of the given \p profile for the given \p connector_id for different profile
+    /// purposes
+    ///
+    std::optional<ocpp::DateTime> get_profile_start_time(const ChargingProfile& profile, const ocpp::DateTime& time,
+                                                         const int evse);
+
+    static int32_t determine_duration(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time);
+
+    static bool within_time_window(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time);
+
+    ///
+    /// \brief Iterates over the periods of the given \p valid_profiles and determines the earliest next absolute period
+    /// end time later than \p temp_time
+    ///
+    ocpp::DateTime get_next_temp_time(const ocpp::DateTime temp_time,
+                                      const std::vector<ChargingProfile>& valid_profiles, const int32_t evse_id);
+
+    ocpp::DateTime get_period_end_time(const int period_index, const ocpp::DateTime& period_start_time,
+                                       const ChargingSchedule& schedule);
+
 private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
     void conform_validity_periods(ChargingProfile& profile) const;
     CurrentPhaseType get_current_phase_type(const std::optional<EvseInterface*> evse_opt) const;
+    CompositeSchedule initialize_composite_schedule(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time,
+                                                    const int32_t evse_id, ChargingRateUnitEnum charging_rate_unit);
+    std::map<ChargingProfilePurposeEnum, LimitStackLevelPair> get_initial_purpose_and_stack_limits();
+
+    std::optional<ocpp::DateTime> get_absolute_profile_start_time(const std::optional<ocpp::DateTime> startSchedule);
+    std::optional<ocpp::DateTime>
+    get_recurring_profile_start_time(const ocpp::DateTime& time, const std::optional<ocpp::DateTime> startSchedule,
+                                     const std::optional<RecurrencyKindEnum> recurrencyKind);
+    std::optional<ocpp::DateTime> get_relative_profile_start_time(const int32_t evse_id);
+    int get_power_limit(const int limit, const int nr_phases, const ChargingRateUnitEnum& unit_of_limit);
 };
 
 } // namespace ocpp::v201

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -64,6 +64,12 @@ ocpp::DateTime align_timestamp(const DateTime timestamp, std::chrono::seconds al
 /// \brief Returns the total Power_Active_Import value from the \p meter_value or std::nullopt if it is not present
 std::optional<float> get_total_power_active_import(const MeterValue& meter_value);
 
+std::string to_string(ChargingProfile cp);
+std::string to_string(ChargingSchedule cs);
+std::string to_string(ChargingSchedulePeriod csp);
+std::string to_string(CompositeSchedule& cs);
+std::string get_log_duration_string(int32_t duration);
+
 } // namespace utils
 } // namespace v201
 } // namespace ocpp

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -11,6 +11,7 @@
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include "ocpp/v201/ocpp_types.hpp"
 #include "ocpp/v201/transaction.hpp"
+#include "ocpp/v201/utils.hpp"
 #include <algorithm>
 #include <iterator>
 #include <memory>
@@ -400,6 +401,401 @@ bool SmartChargingHandler::is_overlapping_validity_period(int candidate_evse_id,
 void SmartChargingHandler::conform_validity_periods(ChargingProfile& profile) const {
     profile.validFrom = profile.validFrom.value_or(ocpp::DateTime());
     profile.validTo = profile.validTo.value_or(ocpp::DateTime(date::utc_clock::time_point::max()));
+}
+
+void log_period_date_time_pair(PeriodDateTimePair period_date_time_pair) {
+    std::string log_str = "PeriodDateTimePair> ";
+
+    if (period_date_time_pair.period.has_value()) {
+        log_str += " period: " + utils::to_string(period_date_time_pair.period.value());
+    }
+    log_str += " end_time: " + period_date_time_pair.end_time.to_rfc3339();
+    EVLOG_info << log_str;
+}
+
+// TODO: The structs type is float but it's being passed in as an int. Significant?
+int get_requested_limit(const int limit, const int nr_phases, const ChargingRateUnitEnum& requested_unit) {
+    if (requested_unit == ChargingRateUnitEnum::A) {
+        return limit / (LOW_VOLTAGE * nr_phases);
+    } else {
+        return limit;
+    }
+}
+
+CompositeSchedule SmartChargingHandler::initialize_composite_schedule(const ocpp::DateTime& start_time,
+                                                                      const ocpp::DateTime& end_time,
+                                                                      const int32_t evse_id,
+                                                                      ChargingRateUnitEnum charging_rate_unit) {
+    CompositeSchedule composite_schedule;
+
+    composite_schedule.evseId = evse_id;
+    composite_schedule.duration = SmartChargingHandler::determine_duration(start_time, end_time);
+    composite_schedule.scheduleStart = start_time;
+    composite_schedule.chargingRateUnit = charging_rate_unit;
+
+    return composite_schedule;
+}
+
+int32_t SmartChargingHandler::determine_duration(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time) {
+    return duration_cast<seconds>(end_time.to_time_point() - start_time.to_time_point()).count();
+}
+
+bool SmartChargingHandler::within_time_window(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time) {
+    return SmartChargingHandler::determine_duration(start_time, end_time) > 0;
+}
+
+PeriodDateTimePair SmartChargingHandler::find_period_at(const ocpp::DateTime& time, const ChargingProfile& profile,
+                                                        const int evse_id) {
+    auto period_start_time = this->get_profile_start_time(profile, time, evse_id);
+
+    EVLOG_info << "#" << profile.id << " find_period_at> " << period_start_time.value().to_rfc3339();
+
+    // TODO: Only processing first charging schedule
+    const auto schedule = profile.chargingSchedule.front();
+
+    if (period_start_time) {
+        const auto periods = schedule.chargingSchedulePeriod;
+        time_point<date::utc_clock> period_end_time;
+        for (size_t i = 0; i < periods.size(); i++) {
+            const auto period_end_time = get_period_end_time(i, period_start_time.value(), schedule);
+
+            EVLOG_info << "   find_period_at>        start_time> " << time.to_rfc3339();
+            EVLOG_info << "   find_period_at> period_start_time> " << period_start_time.value().to_rfc3339();
+            EVLOG_info << "   find_period_at>   period_end_time> " << period_end_time.to_rfc3339();
+
+            if (time >= period_start_time.value() && time < period_end_time) {
+                PeriodDateTimePair date_time_pair = {.period = periods.at(i),
+                                                     .end_time = ocpp::DateTime(period_end_time)};
+                log_period_date_time_pair(date_time_pair);
+                return date_time_pair;
+            }
+            period_start_time.emplace(ocpp::DateTime(period_end_time));
+        }
+    }
+
+    PeriodDateTimePair date_time_pair = {.period = std::nullopt, .end_time = MAX_DATE_TIME};
+    log_period_date_time_pair(date_time_pair);
+    return date_time_pair;
+}
+
+///
+/// \brief Calculates the composite schedule for the given \p valid_profiles and the given \p connector_id
+///
+CompositeSchedule SmartChargingHandler::calculate_composite_schedule(std::vector<ChargingProfile> valid_profiles,
+                                                                     const ocpp::DateTime& start_time,
+                                                                     const ocpp::DateTime& end_time,
+                                                                     const int32_t evse_id,
+                                                                     ChargingRateUnitEnum charging_rate_unit) {
+
+    CompositeSchedule composite_schedule =
+        this->initialize_composite_schedule(start_time, end_time, evse_id, charging_rate_unit);
+
+    std::vector<ChargingSchedulePeriod> periods;
+
+    ocpp::DateTime temp_time(start_time);
+    ocpp::DateTime last_period_end_time(end_time);
+    int current_period_limit = MAX_PERIOD_LIMIT;
+    LimitStackLevelPair significant_limit_stack_level_pair = {MAX_PERIOD_LIMIT, -1};
+
+    // calculate every ChargingSchedulePeriod of result within this while loop
+    while (SmartChargingHandler::within_time_window(temp_time, end_time)) {
+
+        std::map<ChargingProfilePurposeEnum, LimitStackLevelPair> current_purpose_and_stack_limits =
+            get_initial_purpose_and_stack_limits(); // this data structure holds the current lowest limit and stack
+                                                    // level for every purpose
+        ocpp::DateTime temp_period_end_time;
+        int32_t temp_number_phases;
+
+        for (const ChargingProfile& profile : valid_profiles) {
+            EVLOG_info << "ProfileId #" << profile.id << " Kind: " << profile.chargingProfileKind;
+
+            // Only work with this Profile if it has a higher stack level
+            if (profile.stackLevel > current_purpose_and_stack_limits.at(profile.chargingProfilePurpose).stack_level) {
+                // this data structure holds the respective period and period end time for temp_time point in time
+                const PeriodDateTimePair period_date_time_pair = this->find_period_at(temp_time, profile, evse_id);
+
+                if (period_date_time_pair.period.has_value()) {
+                    const ChargingSchedulePeriod period = period_date_time_pair.period.value();
+
+                    temp_period_end_time = period_date_time_pair.end_time;
+
+                    temp_number_phases = period.numberPhases.value_or(DEFAULT_AND_MAX_NUMBER_PHASES);
+
+                    ChargingSchedule first_charging_schedule = profile.chargingSchedule.front();
+
+                    float limit =
+                        get_power_limit(period.limit, temp_number_phases, first_charging_schedule.chargingRateUnit);
+                    int32_t stackLevel = profile.stackLevel;
+
+                    EVLOG_info << "period.has_value() limit = " << limit;
+                    EVLOG_info << "period.has_value() stackLevel = " << limit;
+
+                    // update data structure with limit and stack level for this profile
+                    current_purpose_and_stack_limits.at(profile.chargingProfilePurpose).limit = limit;
+                    current_purpose_and_stack_limits.at(profile.chargingProfilePurpose).stack_level = stackLevel;
+                }
+            }
+        };
+
+        // if there is a limit with purpose TxProfile it overrules the limit of purpose TxDefaultProfile
+        if (current_purpose_and_stack_limits.at(ChargingProfilePurposeEnum::TxProfile).limit != MAX_PERIOD_LIMIT) {
+            significant_limit_stack_level_pair =
+                current_purpose_and_stack_limits.at(ChargingProfilePurposeEnum::TxProfile);
+        } else {
+            significant_limit_stack_level_pair =
+                current_purpose_and_stack_limits.at(ChargingProfilePurposeEnum::TxDefaultProfile);
+        }
+
+        if (current_purpose_and_stack_limits.at(ChargingProfilePurposeEnum::ChargingStationMaxProfile).limit <
+            significant_limit_stack_level_pair.limit) {
+            significant_limit_stack_level_pair =
+                current_purpose_and_stack_limits.at(ChargingProfilePurposeEnum::ChargingStationMaxProfile);
+        }
+
+        bool should_insert_period = significant_limit_stack_level_pair.limit != current_period_limit and
+                                    significant_limit_stack_level_pair.limit != MAX_PERIOD_LIMIT;
+
+        EVLOG_debug << "stack_level_pair.limit(" << significant_limit_stack_level_pair.limit
+                    << ") != current_period_limit(" << current_period_limit << ") and stack_level_pair.limit("
+                    << significant_limit_stack_level_pair.limit << ") != MAX_PERIOD_LIMIT " << MAX_PERIOD_LIMIT
+                    << " == " << should_insert_period;
+
+        // insert new period to result only if limit changed or period was found
+        if (should_insert_period) {
+
+            ChargingSchedulePeriod new_period = ChargingSchedulePeriod{
+                .startPeriod =
+                    static_cast<int32_t>(duration_cast<seconds>(temp_time.to_time_point() - start_time.to_time_point())
+                                             .count()), // Declare and assign the value of start_period to startPeriod
+                .limit = static_cast<float>(get_requested_limit(
+                    significant_limit_stack_level_pair.limit, // TODO: Again why float to int to float?
+                    temp_number_phases, charging_rate_unit)),
+                .numberPhases = temp_number_phases,
+            };
+
+            EVLOG_debug << "calculate_composite_schedule> pushing period " << utils::to_string(new_period);
+
+            periods.push_back(new_period);
+
+            last_period_end_time = temp_period_end_time;
+            current_period_limit = significant_limit_stack_level_pair.limit;
+        }
+        temp_time = this->get_next_temp_time(temp_time, valid_profiles, evse_id);
+    }
+
+    // update duration if end time of last period is smaller than requested end time
+    if (last_period_end_time.to_time_point() - start_time.to_time_point() <
+        (end_time.to_time_point() - start_time.to_time_point())) {
+        composite_schedule.duration = SmartChargingHandler::determine_duration(start_time, last_period_end_time);
+    }
+    composite_schedule.chargingSchedulePeriod = periods;
+
+    return composite_schedule;
+}
+
+ocpp::DateTime SmartChargingHandler::get_period_end_time(const int period_index,
+                                                         const ocpp::DateTime& period_start_time,
+                                                         const ChargingSchedule& schedule) {
+
+    const std::vector<ChargingSchedulePeriod> periods = schedule.chargingSchedulePeriod;
+
+    std::optional<ocpp::DateTime> period_end_time;
+
+    int period_diff_in_seconds;
+    if ((size_t)period_index + 1 < periods.size()) {
+        int duration;
+        if (schedule.duration) {
+            duration = schedule.duration.value();
+        } else {
+            duration = MAX_PERIOD_LIMIT;
+        }
+
+        if (periods.at(period_index + 1).startPeriod < duration) {
+            period_diff_in_seconds = periods.at(period_index + 1).startPeriod - periods.at(period_index).startPeriod;
+        } else {
+            period_diff_in_seconds = duration - periods.at(period_index).startPeriod;
+        }
+        const ocpp::DateTime dt = ocpp::DateTime(period_start_time.to_time_point() + seconds(period_diff_in_seconds));
+        return dt;
+    } else if (schedule.duration) {
+        period_diff_in_seconds = schedule.duration.value() - periods.at(period_index).startPeriod;
+        return ocpp::DateTime(period_start_time.to_time_point() + seconds(period_diff_in_seconds));
+    } else {
+        return MAX_DATE_TIME;
+    }
+}
+
+bool continue_time_arrow(const ocpp::DateTime& temp_time, const ocpp::DateTime& period_start_time,
+                         const ocpp::DateTime& period_end_time, const ocpp::DateTime& lowest_next_time) {
+    // original
+    // return (temp_time >= period_start_time && temp_time < period_end_time && period_end_time < lowest_next_time);
+    // TODO: Add test coverage to ensure that these calculations are correct before removing this comment.
+
+    return (temp_time < period_end_time && period_end_time < lowest_next_time);
+}
+
+// Step 1 - lowest_next_time is set to maximum time in the future
+// Step 2 - Iterate through the profiles
+// Step 3 - Get first starting schedule (only one currently supported)
+// Step 4 - Get period_start_time and continue if available
+// Step 5 - Iterate through the ChargingSchedulePeriods
+// Step 6 - Get Period end time
+// Step 7 - Continue if not within final time window
+ocpp::DateTime SmartChargingHandler::get_next_temp_time(const ocpp::DateTime temp_time,
+                                                        const std::vector<ChargingProfile>& valid_profiles,
+                                                        const int32_t evse_id) {
+    EVLOG_debug << "get_next_temp_time> temp_time = " << temp_time;
+
+    // Step 1 - lowest_next_time is set to maximum tine in the future
+    ocpp::DateTime lowest_next_time = MAX_DATE_TIME;
+
+    EVLOG_debug << "get_next_temp_time> lowest_next_time = " << lowest_next_time;
+
+    // Step 2 - Iterate through the profiles
+    for (const ChargingProfile& profile : valid_profiles) {
+        EVLOG_debug << "get_next_temp_time> ChargingProfile #" << profile.id;
+
+        if (profile.chargingSchedule.size() > 1) {
+            // TODO: Add support for Profiles with more than one ChargingSchedule.
+            EVLOG_warning << "Charging Profiles with more than one ChargingSchedule are not currently supported.";
+        }
+
+        // Step 3 - Get first starting schedule (only one currently supported)
+        ChargingSchedule schedule = profile.chargingSchedule.front();
+        const std::vector<ChargingSchedulePeriod> periods = schedule.chargingSchedulePeriod;
+
+        // Step 4 - Get period_start_time and continue if available
+        const std::optional<ocpp::DateTime> period_start_time_opt =
+            this->get_profile_start_time(profile, temp_time, evse_id);
+
+        if (period_start_time_opt.has_value()) {
+            ocpp::DateTime period_start_time = period_start_time_opt.value();
+
+            EVLOG_debug << "get_next_temp_time> ChargingSchedule #" << schedule.id
+                        << " duration: " << utils::get_log_duration_string(schedule.duration.value())
+                        << " startSchedule: " << schedule.startSchedule.value();
+
+            // Step 5 - Iterate through the ChargingSchedulePeriods
+            for (size_t i = 0; i < periods.size(); i++) {
+                ChargingSchedulePeriod period = periods.at(i);
+
+                // for (const ChargingSchedulePeriod period : schedule.chargingSchedulePeriod) {
+                EVLOG_debug << "get_next_temp_time> ChargingSchedulePeriod #" << i << " limit: " << period.limit
+                            << " startPeriod: " << period.startPeriod;
+
+                // Step 6 - Get Period end time
+                const ocpp::DateTime period_end_time = get_period_end_time(i, period_start_time, schedule);
+                EVLOG_debug << "get_next_temp_time> period_end_time: " << period_end_time;
+
+                bool within_window =
+                    continue_time_arrow(temp_time, period_start_time, period_end_time, lowest_next_time);
+
+                EVLOG_debug << "get_next_temp_time> Profile #" << profile.id << " " << temp_time << " < "
+                            << period_end_time << " && " << period_end_time << " < " << lowest_next_time << " = "
+                            << within_window;
+
+                // Step 7 - Continue if not within final time window
+                if (within_window) {
+                    lowest_next_time = period_end_time;
+                    EVLOG_debug << "get_next_temp_time> Profile #" << profile.id << " " << lowest_next_time
+                                << " is new lowest_next_time";
+                } else {
+                    EVLOG_debug << "get_next_temp_time> Profile #" << profile.id << " " << lowest_next_time
+                                << " is current lowest_next_time NO CHANGE";
+                }
+
+                period_start_time = period_end_time;
+            }
+        }
+    }
+    return lowest_next_time;
+}
+
+std::optional<ocpp::DateTime>
+SmartChargingHandler::get_absolute_profile_start_time(const std::optional<ocpp::DateTime> startSchedule) {
+    std::optional<ocpp::DateTime> period_start_time;
+
+    if (startSchedule) {
+        period_start_time.emplace(ocpp::DateTime(floor<seconds>(startSchedule.value().to_time_point())));
+    } else {
+        EVLOG_warning << "Absolute profile with no startSchedule, this should not be possible";
+    }
+
+    return period_start_time;
+}
+
+std::optional<ocpp::DateTime>
+SmartChargingHandler::get_recurring_profile_start_time(const ocpp::DateTime& time,
+                                                       const std::optional<ocpp::DateTime> startSchedule,
+                                                       const std::optional<RecurrencyKindEnum> recurrencyKind) {
+    std::optional<ocpp::DateTime> period_start_time;
+
+    if (startSchedule) {
+        // TODO ?: What if startSchedule is not set? This use case is not handled in the 1.6 code
+        const ocpp::DateTime start_schedule =
+            ocpp::DateTime(std::chrono::floor<seconds>(startSchedule.value().to_time_point()));
+        int seconds_to_go_back;
+
+        if (recurrencyKind.value() == RecurrencyKindEnum::Daily) {
+            seconds_to_go_back =
+                SmartChargingHandler::determine_duration(start_schedule, time) % (HOURS_PER_DAY * SECONDS_PER_HOUR);
+        } else {
+            seconds_to_go_back =
+                SmartChargingHandler::determine_duration(start_schedule, time) % (SECONDS_PER_DAY * DAYS_PER_WEEK);
+        }
+        auto time_minus_seconds_to_go_back = time.to_time_point() - seconds(seconds_to_go_back);
+        period_start_time.emplace(ocpp::DateTime(time_minus_seconds_to_go_back));
+    } else {
+        EVLOG_warning << "Recurring profile with no startSchedule, this should not be possible";
+    }
+
+    return period_start_time;
+}
+
+// TODO: Needed for future work on relative profile.
+std::optional<ocpp::DateTime> SmartChargingHandler::get_relative_profile_start_time(const int32_t evse_id) {
+    std::optional<ocpp::DateTime> period_start_time;
+
+    return period_start_time;
+}
+
+std::optional<ocpp::DateTime> SmartChargingHandler::get_profile_start_time(const ChargingProfile& profile,
+                                                                           const ocpp::DateTime& time,
+                                                                           const int32_t evse_id) {
+
+    std::optional<ocpp::DateTime> period_start_time;
+
+    // TODO add test logic for returning only one value for multiple Charging Schedules. Currently not supported.
+    for (const ChargingSchedule schedule : profile.chargingSchedule) {
+        if (profile.chargingProfileKind == ChargingProfileKindEnum::Absolute) {
+            period_start_time = SmartChargingHandler::get_absolute_profile_start_time(schedule.startSchedule);
+        } else if (profile.chargingProfileKind == ChargingProfileKindEnum::Relative) {
+            // TODO: Needs to be finished
+        } else if (profile.chargingProfileKind == ChargingProfileKindEnum::Recurring) {
+            period_start_time = SmartChargingHandler::get_recurring_profile_start_time(time, schedule.startSchedule,
+                                                                                       profile.recurrencyKind);
+        }
+    }
+    EVLOG_verbose << "get_profile_start_time> profile #" << profile.id << " temp_time: " << time.to_rfc3339()
+                  << " period_start_time: " << period_start_time.value().to_rfc3339() << " EVSE_ID #" << evse_id;
+    return period_start_time;
+}
+
+std::map<ChargingProfilePurposeEnum, LimitStackLevelPair> SmartChargingHandler::get_initial_purpose_and_stack_limits() {
+    std::map<ChargingProfilePurposeEnum, LimitStackLevelPair> map;
+    map[ChargingProfilePurposeEnum::ChargingStationMaxProfile] = {MAX_PERIOD_LIMIT, -1};
+    map[ChargingProfilePurposeEnum::TxDefaultProfile] = {MAX_PERIOD_LIMIT, -1};
+    map[ChargingProfilePurposeEnum::TxProfile] = {MAX_PERIOD_LIMIT, -1};
+    return map;
+}
+
+int SmartChargingHandler::get_power_limit(const int limit, const int nr_phases,
+                                          const ChargingRateUnitEnum& unit_of_limit) {
+    if (unit_of_limit == ChargingRateUnitEnum::W) {
+        return limit;
+    } else {
+        return limit * LOW_VOLTAGE * nr_phases;
+    }
 }
 
 } // namespace ocpp::v201

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -192,6 +192,68 @@ std::optional<float> get_total_power_active_import(const MeterValue& meter_value
     return std::nullopt;
 }
 
+std::string to_string(ChargingProfile cp) {
+    json cp_json;
+    to_json(cp_json, cp);
+
+    return cp_json.dump(4);
+};
+
+std::string to_string(ChargingSchedule cs) {
+    json cs_json;
+    to_json(cs_json, cs);
+
+    return cs_json.dump(4);
+};
+
+std::string to_string(ChargingSchedulePeriod csp) {
+    json csp_json;
+    to_json(csp_json, csp);
+
+    return csp_json.dump(4);
+};
+
+std::string to_string(CompositeSchedule& cs) {
+    json cs_json;
+    to_json(cs_json, cs);
+
+    return cs_json.dump(4);
+}
+
+std::string get_log_duration_string(int32_t duration) {
+    if (duration < 1) {
+        return "0 Seconds ";
+    }
+
+    int32_t remaining = duration;
+
+    std::string log_str = "";
+
+    if (remaining >= 86400) {
+        int32_t days = remaining / 86400;
+        remaining = remaining % 86400;
+        if (days > 1) {
+            log_str += std::to_string(days) + " Days ";
+        } else {
+            log_str += std::to_string(days) + " Day ";
+        }
+    }
+    if (remaining >= 3600) {
+        int32_t hours = remaining / 3600;
+        remaining = remaining % 3600;
+        log_str += std::to_string(hours) + " Hours ";
+    }
+    if (remaining >= 60) {
+        int32_t minutes = remaining / 60;
+        remaining = remaining % 60;
+        log_str += std::to_string(minutes) + " Minutes ";
+    }
+    if (remaining > 0) {
+        log_str += std::to_string(remaining) + " Seconds ";
+    }
+    return log_str;
+}
+
 } // namespace utils
 } // namespace v201
 } // namespace ocpp

--- a/tests/lib/ocpp/v16/CMakeLists.txt
+++ b/tests/lib/ocpp/v16/CMakeLists.txt
@@ -1,4 +1,7 @@
 target_sources(libocpp_unit_tests PRIVATE
+        test_composite_schedule.cpp
         test_database_migration_files.cpp
         test_smart_charging_handler.cpp
-        )
+)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/json DESTINATION /tmp/EVerest/libocpp/v16)

--- a/tests/lib/ocpp/v16/json/TxDefaultProfile_01.json
+++ b/tests/lib/ocpp/v16/json/TxDefaultProfile_01.json
@@ -1,0 +1,20 @@
+{
+  "chargingProfileId": 1,
+  "chargingProfileKind": "Absolute",
+  "chargingProfilePurpose": "TxDefaultProfile",
+  "chargingSchedule": {
+    "chargingRateUnit": "W",
+    "chargingSchedulePeriod": [
+      {
+        "limit": 2000.0,
+        "numberPhases": 1,
+        "startPeriod": 0
+      }
+    ],
+    "duration": 1080,
+    "minChargingRate": 0.0,
+    "startSchedule": "2024-01-17T18:00:00.000Z"
+  },
+  "recurrencyKind": "Daily",
+  "stackLevel": 1
+}

--- a/tests/lib/ocpp/v16/json/TxDefaultProfile_100.json
+++ b/tests/lib/ocpp/v16/json/TxDefaultProfile_100.json
@@ -1,0 +1,30 @@
+{
+    "chargingProfileId": 100,
+    "chargingProfileKind": "Recurring",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": {
+        "chargingRateUnit": "W",
+        "chargingSchedulePeriod": [
+            {
+                "limit": 11000.0,
+                "numberPhases": 3,
+                "startPeriod": 0
+            },
+            {
+                "limit": 6000.0,
+                "numberPhases": 3,
+                "startPeriod": 28800
+            },
+            {
+                "limit": 12000.0,
+                "numberPhases": 3,
+                "startPeriod": 72000
+            }
+        ],
+        "duration": 86400,
+        "minChargingRate": 0.0,
+        "startSchedule": "2023-01-17T17:00:00.000Z"
+    },
+    "recurrencyKind": "Daily",
+    "stackLevel": 0
+}

--- a/tests/lib/ocpp/v16/json/TxDefaultProfile_2kw_17-20.json
+++ b/tests/lib/ocpp/v16/json/TxDefaultProfile_2kw_17-20.json
@@ -1,0 +1,20 @@
+{
+    "chargingProfileId": 10,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": {
+        "chargingRateUnit": "W",
+        "chargingSchedulePeriod": [
+            {
+                "limit": 2000.0,
+                "numberPhases": 1,
+                "startPeriod": 0
+            }
+        ],
+        "duration": 1080,
+        "minChargingRate": 0.0,
+        "startSchedule": "2024-01-17T17:00:00.000Z"
+    },
+    "recurrencyKind": "Daily",
+    "stackLevel": 1
+}

--- a/tests/lib/ocpp/v16/json/TxDefaultProfile_Absolute_Daily_2kw_1080.json
+++ b/tests/lib/ocpp/v16/json/TxDefaultProfile_Absolute_Daily_2kw_1080.json
@@ -1,0 +1,20 @@
+{
+    "chargingProfileId": 11,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": {
+        "chargingRateUnit": "W",
+        "chargingSchedulePeriod": [
+            {
+                "limit": 2000.0,
+                "numberPhases": 1,
+                "startPeriod": 0
+            }
+        ],
+        "duration": 1080,
+        "minChargingRate": 0.0,
+        "startSchedule": "2024-01-17T17:00:00.000Z"
+    },
+    "recurrencyKind": "Daily",
+    "stackLevel": 1
+}

--- a/tests/lib/ocpp/v16/json/TxDefaultProfile_no_chargingRateUnit.json
+++ b/tests/lib/ocpp/v16/json/TxDefaultProfile_no_chargingRateUnit.json
@@ -1,0 +1,19 @@
+{
+    "chargingProfileId": 1,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": {
+        "chargingSchedulePeriod": [
+            {
+                "limit": 2000.0,
+                "numberPhases": 1,
+                "startPeriod": 0
+            }
+        ],
+        "duration": 1080,
+        "minChargingRate": 0.0,
+        "startSchedule": "2024-01-17T17:00:00.000Z"
+    },
+    "recurrencyKind": "Daily",
+    "stackLevel": 1
+}

--- a/tests/lib/ocpp/v16/json/TxProfile_02.json
+++ b/tests/lib/ocpp/v16/json/TxProfile_02.json
@@ -1,0 +1,19 @@
+{
+    "chargingProfileId": 2,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxProfile",
+    "chargingSchedule": {
+        "chargingRateUnit": "W",
+        "chargingSchedulePeriod": [
+            {
+                "limit": 2000.0,
+                "numberPhases": 1,
+                "startPeriod": 0
+            }
+        ],
+        "duration": 1080,
+        "minChargingRate": 0.0,
+        "startSchedule": "2024-01-17T18:00:30.000Z"
+    },
+    "stackLevel": 2
+}

--- a/tests/lib/ocpp/v16/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v16/test_composite_schedule.cpp
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#include <filesystem>
+#include <fstream>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <vector>
+namespace fs = std::filesystem;
+
+#include "everest/logging.hpp"
+#include <database_handler_mock.hpp>
+#include <evse_security_mock.hpp>
+#include <ocpp/common/call_types.hpp>
+#include <ocpp/common/evse_security_impl.hpp>
+#include <ocpp/v16/charge_point_impl.hpp>
+#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/smart_charging.hpp>
+#include <optional>
+
+namespace ocpp {
+namespace v16 {
+
+/**
+ * CompositeSchedule Test Fixture
+ */
+class CompositeScheduleTestFixture : public testing::Test {
+protected:
+    void SetUp() override {
+        this->evse_security = std::make_shared<EvseSecurityMock>();
+    }
+
+    void add_connector(int id) {
+        auto connector = Connector{id};
+
+        auto timer = std::unique_ptr<Everest::SteadyTimer>();
+
+        connector.transaction =
+            std::make_shared<Transaction>(-1, id, "test", "test", 1, std::nullopt, ocpp::DateTime(), std::move(timer));
+        connectors[id] = std::make_shared<Connector>(connector);
+    }
+
+    SmartChargingHandler* create_smart_charging_handler(const int number_of_connectors) {
+        for (int i = 0; i <= number_of_connectors; i++) {
+            add_connector(i);
+        }
+
+        const std::string chargepoint_id = "1";
+        const fs::path database_path = "na";
+        const fs::path init_script_path = "na";
+
+        auto database = std::make_unique<common::DatabaseConnection>(database_path / (chargepoint_id + ".db"));
+        std::shared_ptr<testing::NiceMock<DatabaseHandlerMock>> database_handler =
+            std::make_shared<testing::NiceMock<DatabaseHandlerMock>>(std::move(database), init_script_path);
+
+        auto handler = new SmartChargingHandler(connectors, database_handler, true);
+
+        return handler;
+    }
+
+    ChargingProfile get_charging_profile_from_file(const std::string& filename) {
+        const std::string base_path = "/tmp/EVerest/libocpp/v16/json/";
+        const std::string full_path = base_path + filename;
+
+        std::ifstream f(full_path.c_str());
+        json data = json::parse(f);
+
+        ChargingProfile cp;
+        from_json(data, cp);
+        return cp;
+    }
+
+    std::string get_log_duration_string(int32_t duration) {
+        if (duration < 1) {
+            return "0 Seconds ";
+        }
+
+        int32_t remaining = duration;
+
+        std::string log_str = "";
+
+        if (remaining >= 86400) {
+            int32_t days = remaining / 86400;
+            remaining = remaining % 86400;
+            if (days > 1) {
+                log_str += std::to_string(days) + " Days ";
+            } else {
+                log_str += std::to_string(days) + " Day ";
+            }
+        }
+        if (remaining >= 3600) {
+            int32_t hours = remaining / 3600;
+            remaining = remaining % 3600;
+            log_str += std::to_string(hours) + " Hours ";
+        }
+        if (remaining >= 60) {
+            int32_t minutes = remaining / 60;
+            remaining = remaining % 60;
+            log_str += std::to_string(minutes) + " Minutes ";
+        }
+        if (remaining > 0) {
+            log_str += std::to_string(remaining) + " Seconds ";
+        }
+        return log_str;
+    }
+
+    void log_duration(int32_t duration) {
+        EVLOG_info << get_log_duration_string(duration);
+    }
+
+    void log_me(ChargingProfile& cp) {
+        json cp_json;
+        to_json(cp_json, cp);
+
+        EVLOG_info << "  ChargingProfile> " << cp_json.dump(4);
+        log_duration(cp.chargingSchedule.duration.value_or(0));
+    }
+
+    void log_me(std::vector<ChargingProfile> profiles) {
+        EVLOG_info << "[";
+        for (auto& profile : profiles) {
+            log_me(profile);
+        }
+        EVLOG_info << "]";
+    }
+
+    void log_me(EnhancedChargingSchedule& ecs) {
+        json ecs_json;
+        to_json(ecs_json, ecs);
+
+        EVLOG_info << "EnhancedChargingSchedule> " << ecs_json.dump(4);
+    }
+
+    void log_me(EnhancedChargingSchedule& ecs, const DateTime start_time) {
+        log_me(ecs);
+        EVLOG_info << "Start Time> " << start_time.to_rfc3339();
+
+        int32_t i = 0;
+        for (auto& period : ecs.chargingSchedulePeriod) {
+            i++;
+            int32_t numberPhases = 0;
+            if (period.numberPhases.has_value()) {
+                numberPhases = period.numberPhases.value();
+            }
+            EVLOG_info << "   period #" << i << " {limit: " << period.limit << " numberPhases:" << numberPhases
+                       << " stackLevel:" << period.stackLevel << "} starts "
+                       << get_log_duration_string(period.startPeriod) << "in";
+        }
+        if (ecs.duration.has_value()) {
+            EVLOG_info << "   period #" << i << " ends after " << get_log_duration_string(ecs.duration.value());
+        } else {
+            EVLOG_info << "   period #" << i << " ends in 0 Seconds";
+        }
+    }
+
+    /// \brief Returns a vector of ChargingProfiles to be used as a baseline for testing core functionality
+    /// of generating an EnhancedChargingSchedule.
+    std::vector<ChargingProfile> getBaselineProfileVector() {
+        auto profile_01 = get_charging_profile_from_file("TxDefaultProfile_01.json");
+        // auto profile_02 = getChargingProfileFromFile("TxDefaultProfile_02.json");
+        auto profile_100 = get_charging_profile_from_file("TxDefaultProfile_100.json");
+        // return {profile_01, profile_02, profile_100};
+        return {profile_01, profile_100};
+    }
+
+    // Default values used within the tests
+    std::map<int32_t, std::shared_ptr<Connector>> connectors;
+    std::shared_ptr<DatabaseHandler> database_handler;
+    std::shared_ptr<EvseSecurityMock> evse_security;
+};
+
+TEST_F(CompositeScheduleTestFixture, CalculateEnhancedCompositeSchedule_ValidatedBaseline) {
+    // GTEST_SKIP();
+    auto handler = create_smart_charging_handler(1);
+    std::vector<ChargingProfile> profiles = getBaselineProfileVector();
+    log_me(profiles);
+
+    const DateTime my_date_start_range = ocpp::DateTime("2024-01-17T18:01:00");
+    const DateTime my_date_end_range = ocpp::DateTime("2024-01-18T06:00:00");
+
+    EVLOG_info << "    Start> " << my_date_start_range.to_rfc3339();
+    EVLOG_info << "      End> " << my_date_end_range.to_rfc3339();
+
+    auto composite_schedule = handler->calculate_enhanced_composite_schedule(
+        profiles, my_date_start_range, my_date_end_range, 1, profiles.at(0).chargingSchedule.chargingRateUnit);
+
+    log_me(composite_schedule, my_date_start_range);
+
+    ASSERT_EQ(composite_schedule.chargingRateUnit, ChargingRateUnit::W);
+    ASSERT_EQ(composite_schedule.duration, 43140);
+    ASSERT_EQ(profiles.size(), 2);
+    ASSERT_EQ(composite_schedule.chargingSchedulePeriod.size(), 3);
+    auto& period_01 = composite_schedule.chargingSchedulePeriod.at(0);
+    ASSERT_EQ(period_01.limit, 2000);
+    ASSERT_EQ(period_01.numberPhases, 1);
+    ASSERT_EQ(period_01.stackLevel, 1);
+    ASSERT_EQ(period_01.startPeriod, 0);
+    auto& period_02 = composite_schedule.chargingSchedulePeriod.at(1);
+    ASSERT_EQ(period_02.limit, 11000);
+    ASSERT_EQ(period_02.numberPhases, 3);
+    ASSERT_EQ(period_02.stackLevel, 0);
+    ASSERT_EQ(period_02.startPeriod, 1020);
+    auto& period_03 = composite_schedule.chargingSchedulePeriod.at(2);
+    ASSERT_EQ(period_03.limit, 6000.0);
+    ASSERT_EQ(period_03.numberPhases, 3);
+    ASSERT_EQ(period_03.stackLevel, 0);
+    ASSERT_EQ(period_03.startPeriod, 25140);
+}
+
+TEST_F(CompositeScheduleTestFixture, CalculateEnhancedCompositeSchedule_Baseline__PossibleDefect) {
+    GTEST_SKIP();
+    auto handler = create_smart_charging_handler(1);
+
+    std::vector<ChargingProfile> profiles = getBaselineProfileVector();
+    log_me(profiles);
+
+    const DateTime my_date_start_range = ocpp::DateTime("2024-01-17T17:59:59");
+    const DateTime my_date_end_range = ocpp::DateTime("2024-01-18T00:00:00");
+
+    EVLOG_info << "    Start> " << my_date_start_range.to_rfc3339();
+    EVLOG_info << "      End> " << my_date_end_range.to_rfc3339();
+
+    auto composite_schedule = handler->calculate_enhanced_composite_schedule(
+        profiles, my_date_start_range, my_date_end_range, 1, profiles.at(0).chargingSchedule.chargingRateUnit);
+
+    log_me(composite_schedule, my_date_start_range);
+}
+
+TEST_F(CompositeScheduleTestFixture, CalculateEnhancedCompositeSchedule_TxProfile) {
+    GTEST_SKIP();
+    auto handler = create_smart_charging_handler(1);
+
+    ChargingProfile profile_01 = get_charging_profile_from_file("TxDefaultProfile_01.json");
+    ChargingProfile txprofile_02 = get_charging_profile_from_file("TxProfile_02.json");
+    ChargingProfile profile_100 = get_charging_profile_from_file("TxDefaultProfile_100.json");
+
+    std::vector<ChargingProfile> profiles = {profile_01, txprofile_02, profile_100};
+    log_me(profiles);
+
+    const DateTime my_date_start_range = ocpp::DateTime("2024-01-17T18:01:00");
+    const DateTime my_date_end_range = ocpp::DateTime("2024-01-18T00:00:00");
+
+    EVLOG_info << "    Start> " << my_date_start_range.to_rfc3339();
+    EVLOG_info << "      End> " << my_date_end_range.to_rfc3339();
+
+    auto composite_schedule = handler->calculate_enhanced_composite_schedule(
+        profiles, my_date_start_range, my_date_end_range, 1, profiles.at(0).chargingSchedule.chargingRateUnit);
+}
+
+} // namespace v16
+} // namespace ocpp

--- a/tests/lib/ocpp/v201/CMakeLists.txt
+++ b/tests/lib/ocpp/v201/CMakeLists.txt
@@ -7,5 +7,10 @@ target_sources(libocpp_unit_tests PRIVATE
         test_notify_report_requests_splitter.cpp
         test_ocsp_updater.cpp
         test_component_state_manager.cpp
+        test_composite_schedule.cpp
         test_device_model.cpp
-        test_smart_charging_handler.cpp)
+        test_smart_charging_handler.cpp
+        smart_charging_test_utils.hpp
+        )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/json DESTINATION /tmp/EVerest/libocpp/v201)

--- a/tests/lib/ocpp/v201/json/README.md
+++ b/tests/lib/ocpp/v201/json/README.md
@@ -1,0 +1,2 @@
+# Sample Smart Charging Profiles for Testing
+

--- a/tests/lib/ocpp/v201/json/baseline/TxProfile_1.json
+++ b/tests/lib/ocpp/v201/json/baseline/TxProfile_1.json
@@ -1,0 +1,24 @@
+{
+    "id": 1,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxProfile",
+    "chargingSchedule": [
+        {
+            "id": 0,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 2000.0,
+                    "numberPhases": 1,
+                    "startPeriod": 0
+                }
+            ],
+            "duration": 1080,
+            "minChargingRate": 0.0,
+            "startSchedule": "2024-01-17T18:00:00.000Z"
+        }
+    ],
+    "recurrencyKind": "Daily",
+    "stackLevel": 1,
+    "transactionId": "f1522902-1170-416f-8e43-9e3bce28fab7"
+}

--- a/tests/lib/ocpp/v201/json/baseline/TxProfile_100.json
+++ b/tests/lib/ocpp/v201/json/baseline/TxProfile_100.json
@@ -1,0 +1,34 @@
+{
+    "id": 100,
+    "stackLevel": 0,
+    "chargingProfilePurpose": "TxProfile",
+    "chargingProfileKind": "Recurring",
+    "recurrencyKind": "Daily",
+    "chargingSchedule": [
+        {
+            "id": 1,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 11000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 0
+                },
+                {
+                    "limit": 6000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 28800
+                },
+                {
+                    "limit": 12000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 72000
+                }
+            ],
+            "duration": 86400,
+            "minChargingRate": 0.0,
+            "startSchedule": "2023-01-17T17:00:00.000Z"
+        }
+    ],
+    "transactionId": "f1522902-1170-416f-8e43-9e3bce28fab8"
+}

--- a/tests/lib/ocpp/v201/json/concerning/TxProfile_PAIN_too_long.json
+++ b/tests/lib/ocpp/v201/json/concerning/TxProfile_PAIN_too_long.json
@@ -1,0 +1,34 @@
+{
+    "id": 100,
+    "stackLevel": 0,
+    "chargingProfilePurpose": "TxProfile",
+    "chargingProfileKind": "Recurring",
+    "recurrencyKind": "Daily",
+    "chargingSchedule": [
+        {
+            "id": 1,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 11000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 0
+                },
+                {
+                    "limit": 6000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 28800
+                },
+                {
+                    "limit": 12000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 72100
+                }
+            ],
+            "duration": 86400,
+            "minChargingRate": 0.0,
+            "startSchedule": "2023-01-17T17:00:00.000Z"
+        }
+    ],
+    "transactionId": "f1522902-1170-416f-8e43-9e3bce28fab8"
+}

--- a/tests/lib/ocpp/v201/json/concerning/TxProfile_PAIN_too_many.json
+++ b/tests/lib/ocpp/v201/json/concerning/TxProfile_PAIN_too_many.json
@@ -1,0 +1,44 @@
+{
+    "id": 100,
+    "stackLevel": 0,
+    "chargingProfilePurpose": "TxProfile",
+    "chargingProfileKind": "Recurring",
+    "recurrencyKind": "Daily",
+    "chargingSchedule": [
+        {
+            "id": 1,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 11000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 0
+                },
+                {
+                    "limit": 6000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 28800
+                },
+                {
+                    "limit": 12000.0,
+                    "numberPhases": 3,
+                    "startPeriod": 72100
+                },
+                {
+                    "limit": 12005.0,
+                    "numberPhases": 3,
+                    "startPeriod": 73010
+                },
+                {
+                    "limit": 12010.0,
+                    "numberPhases": 3,
+                    "startPeriod": 74020
+                }
+            ],
+            "duration": 86400,
+            "minChargingRate": 0.0,
+            "startSchedule": "2023-01-17T17:00:00.000Z"
+        }
+    ],
+    "transactionId": "f1522902-1170-416f-8e43-9e3bce28fab8"
+}

--- a/tests/lib/ocpp/v201/smart_charging_test_utils.hpp
+++ b/tests/lib/ocpp/v201/smart_charging_test_utils.hpp
@@ -1,0 +1,83 @@
+#include "ocpp/v201/ocpp_types.hpp"
+#include "ocpp/v201/utils.hpp"
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <openssl/evp.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <sstream>
+#include <vector>
+
+namespace ocpp::v201 {
+
+static const std::string BASE_JSON_PATH = "/tmp/EVerest/libocpp/v201/json/";
+
+class SmartChargingTestUtils {
+public:
+    static std::vector<ChargingProfile> get_charging_profiles_from_directory(const std::string& path) {
+        std::vector<ChargingProfile> profiles;
+        for (const auto& entry : fs::directory_iterator(path)) {
+            if (!entry.is_directory()) {
+                fs::path path = entry.path();
+                if (path.extension() == ".json") {
+                    ChargingProfile profile = get_charging_profile_from_path(path);
+                    std::cout << path << std::endl;
+                    profiles.push_back(profile);
+                }
+            }
+        }
+        return profiles;
+    }
+
+    static ChargingProfile get_charging_profile_from_path(const std::string& path) {
+        std::ifstream f(path.c_str());
+        json data = json::parse(f);
+
+        ChargingProfile cp;
+        from_json(data, cp);
+        return cp;
+    }
+
+    static ChargingProfile get_charging_profile_from_file(const std::string& filename) {
+        const std::string full_path = BASE_JSON_PATH + filename;
+
+        return get_charging_profile_from_path(full_path);
+    }
+
+    /// \brief Returns a vector of ChargingProfiles to be used as a baseline for testing core functionality
+    /// of generating an EnhancedChargingSchedule.
+    static std::vector<ChargingProfile> get_baseline_profile_vector() {
+        return get_charging_profiles_from_directory(BASE_JSON_PATH + "baseline/");
+    }
+
+    static std::string to_string(std::vector<ChargingProfile>& profiles) {
+        std::string s;
+        for (auto& profile : profiles) {
+            if (!s.empty())
+                s += ", ";
+            s += utils::to_string(profile);
+        }
+
+        return "[" + s + "]";
+    }
+
+    static std::string md5hash(std::string s) {
+        unsigned char hash[MD5_DIGEST_LENGTH];
+
+        EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(mdctx, EVP_md5(), NULL);
+        EVP_DigestUpdate(mdctx, s.c_str(), s.size());
+        EVP_DigestFinal_ex(mdctx, hash, NULL);
+        EVP_MD_CTX_free(mdctx);
+
+        std::ostringstream sout;
+        for (int i = 0; i < MD5_DIGEST_LENGTH; i++) {
+            sout << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+        }
+
+        return sout.str();
+    }
+};
+
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_component_state_manager.cpp
+++ b/tests/lib/ocpp/v201/test_component_state_manager.cpp
@@ -67,6 +67,7 @@ public:
 class ComponentStateManagerTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        testing::FLAGS_gmock_verbose = "error";
     }
 
     ComponentStateManager component_state_manager(std::shared_ptr<DatabaseHandler> database,

--- a/tests/lib/ocpp/v201/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v201/test_composite_schedule.cpp
@@ -1,0 +1,441 @@
+#include "date/tz.h"
+#include "everest/logging.hpp"
+#include "ocpp/v201/ctrlr_component_variables.hpp"
+#include "ocpp/v201/device_model_storage_sqlite.hpp"
+#include "ocpp/v201/ocpp_types.hpp"
+#include "ocpp/v201/utils.hpp"
+#include <algorithm>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <sqlite3.h>
+#include <string>
+
+#include <component_state_manager_mock.hpp>
+#include <device_model_storage_mock.hpp>
+#include <evse_mock.hpp>
+#include <evse_security_mock.hpp>
+#include <ocpp/common/call_types.hpp>
+#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/evse.hpp>
+#include <ocpp/v201/smart_charging.hpp>
+#include <optional>
+
+#include "smart_charging_test_utils.hpp"
+
+#include <sstream>
+#include <vector>
+
+namespace ocpp::v201 {
+
+static const int STATION_WIDE_ID = 0;
+static const int DEFAULT_EVSE_ID = 1;
+static const int DEFAULT_PROFILE_ID = 1;
+static const int DEFAULT_STACK_LEVEL = 1;
+
+// static const std::string BASE_JSON_PATH = "/tmp/EVerest/libocpp/v201/json/";
+
+class TestSmartChargingHandler : public SmartChargingHandler {
+public:
+    using SmartChargingHandler::determine_duration;
+    using SmartChargingHandler::get_next_temp_time;
+    using SmartChargingHandler::get_period_end_time;
+    using SmartChargingHandler::get_profile_start_time;
+    using SmartChargingHandler::within_time_window;
+
+    TestSmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
+                             std::shared_ptr<DeviceModel>& device_model) :
+        SmartChargingHandler(evses, device_model) {
+    }
+};
+
+class ChargepointTestFixtureV201 : public testing::Test {
+protected:
+    void SetUp() override {
+    }
+
+    void TearDown() override {
+        sqlite3_close(this->db_handle);
+    }
+
+    ChargingSchedule create_charge_schedule(ChargingRateUnitEnum charging_rate_unit) {
+        int32_t id;
+        std::vector<ChargingSchedulePeriod> charging_schedule_period;
+        std::optional<CustomData> custom_data;
+        std::optional<ocpp::DateTime> start_schedule;
+        std::optional<int32_t> duration;
+        std::optional<float> min_charging_rate;
+        std::optional<SalesTariff> sales_tariff;
+
+        return ChargingSchedule{
+            .id = id,
+            .chargingRateUnit = charging_rate_unit,
+            .chargingSchedulePeriod = charging_schedule_period,
+            .customData = custom_data,
+            .startSchedule = start_schedule,
+            .duration = duration,
+            .minChargingRate = min_charging_rate,
+            .salesTariff = sales_tariff,
+        };
+    }
+
+    ChargingSchedule create_charge_schedule(ChargingRateUnitEnum charging_rate_unit,
+                                            std::vector<ChargingSchedulePeriod> charging_schedule_period,
+                                            std::optional<ocpp::DateTime> start_schedule = std::nullopt) {
+        int32_t id;
+        std::optional<CustomData> custom_data;
+        std::optional<int32_t> duration;
+        std::optional<float> min_charging_rate;
+        std::optional<SalesTariff> sales_tariff;
+
+        return ChargingSchedule{
+            .id = id,
+            .chargingRateUnit = charging_rate_unit,
+            .chargingSchedulePeriod = charging_schedule_period,
+            .customData = custom_data,
+            .startSchedule = start_schedule,
+            .duration = duration,
+            .minChargingRate = min_charging_rate,
+            .salesTariff = sales_tariff,
+        };
+    }
+
+    std::vector<ChargingSchedulePeriod>
+    create_charging_schedule_periods(int32_t start_period, std::optional<int32_t> number_phases = std::nullopt,
+                                     std::optional<int32_t> phase_to_use = std::nullopt) {
+        auto charging_schedule_period = ChargingSchedulePeriod{
+            .startPeriod = start_period,
+            .numberPhases = number_phases,
+            .phaseToUse = phase_to_use,
+        };
+
+        return {charging_schedule_period};
+    }
+
+    std::vector<ChargingSchedulePeriod> create_charging_schedule_periods(std::vector<int32_t> start_periods) {
+        auto charging_schedule_periods = std::vector<ChargingSchedulePeriod>();
+        for (auto start_period : start_periods) {
+            auto charging_schedule_period = ChargingSchedulePeriod{
+                .startPeriod = start_period,
+            };
+            charging_schedule_periods.push_back(charging_schedule_period);
+        }
+
+        return charging_schedule_periods;
+    }
+
+    std::vector<ChargingSchedulePeriod>
+    create_charging_schedule_periods_with_phases(int32_t start_period, int32_t numberPhases, int32_t phaseToUse) {
+        auto charging_schedule_period =
+            ChargingSchedulePeriod{.startPeriod = start_period, .numberPhases = numberPhases, .phaseToUse = phaseToUse};
+
+        return {charging_schedule_period};
+    }
+
+    ChargingProfile
+    create_charging_profile(int32_t charging_profile_id, ChargingProfilePurposeEnum charging_profile_purpose,
+                            ChargingSchedule charging_schedule, std::string transaction_id,
+                            ChargingProfileKindEnum charging_profile_kind = ChargingProfileKindEnum::Absolute,
+                            int stack_level = DEFAULT_STACK_LEVEL) {
+        auto recurrency_kind = RecurrencyKindEnum::Daily;
+        std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
+        return ChargingProfile{.id = charging_profile_id,
+                               .stackLevel = stack_level,
+                               .chargingProfilePurpose = charging_profile_purpose,
+                               .chargingProfileKind = charging_profile_kind,
+                               .chargingSchedule = charging_schedules,
+                               .customData = {},
+                               .recurrencyKind = recurrency_kind,
+                               .validFrom = {},
+                               .validTo = {},
+                               .transactionId = transaction_id};
+    }
+
+    void create_device_model_db(const std::string& path) {
+        sqlite3* source_handle;
+        sqlite3_open(DEVICE_MODEL_DB_LOCATION_V201, &source_handle);
+        sqlite3_open(path.c_str(), &db_handle);
+
+        auto* backup = sqlite3_backup_init(db_handle, "main", source_handle, "main");
+        sqlite3_backup_step(backup, -1);
+        sqlite3_backup_finish(backup);
+
+        sqlite3_close(source_handle);
+    }
+
+    std::shared_ptr<DeviceModel>
+    create_device_model(const std::string& path = "file:device_model?mode=memory&cache=shared",
+                        const std::optional<std::string> ac_phase_switching_supported = "true") {
+        create_device_model_db(path);
+        auto device_model_storage = std::make_unique<DeviceModelStorageSqlite>(path);
+        auto device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
+
+        // Defaults
+        const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
+        device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
+                                AttributeEnum::Actual, "A,W", true);
+
+        const auto& ac_phase_switching_cv = ControllerComponentVariables::ACPhaseSwitchingSupported;
+        device_model->set_value(ac_phase_switching_cv.component, ac_phase_switching_cv.variable.value(),
+                                AttributeEnum::Actual, ac_phase_switching_supported.value_or(""), true);
+
+        return device_model;
+    }
+
+    void create_evse_with_id(int id) {
+        testing::MockFunction<void(const MeterValue& meter_value, const Transaction& transaction, const int32_t seq_no,
+                                   const std::optional<int32_t> reservation_id)>
+            transaction_meter_value_req_mock;
+        testing::MockFunction<void()> pause_charging_callback_mock;
+        auto e1 = std::make_unique<Evse>(
+            id, 1, *device_model, database_handler, std::make_shared<ComponentStateManagerMock>(),
+            transaction_meter_value_req_mock.AsStdFunction(), pause_charging_callback_mock.AsStdFunction());
+        evses[id] = std::move(e1);
+    }
+
+    TestSmartChargingHandler create_smart_charging_handler() {
+        return TestSmartChargingHandler(evses, device_model);
+    }
+
+    std::string uuid() {
+        std::stringstream s;
+        s << uuid_generator();
+        return s.str();
+    }
+
+    void open_evse_transaction(int evse_id, std::string transaction_id) {
+        auto connector_id = 1;
+        auto meter_start = MeterValue();
+        auto id_token = IdToken();
+        auto date_time = ocpp::DateTime("2024-01-17T17:00:00");
+        evses[evse_id]->open_transaction(
+            transaction_id, connector_id, date_time, meter_start, id_token, {}, {},
+            std::chrono::seconds(static_cast<int64_t>(1)), std::chrono::seconds(static_cast<int64_t>(1)),
+            std::chrono::seconds(static_cast<int64_t>(1)), std::chrono::seconds(static_cast<int64_t>(1)));
+    }
+
+    void install_profile_on_evse(int evse_id, int profile_id) {
+        if (evse_id != STATION_WIDE_ID) {
+            create_evse_with_id(evse_id);
+        }
+        auto existing_profile = create_charging_profile(profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                                        create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+        handler.add_profile(evse_id, existing_profile);
+    }
+
+    void log_me(std::vector<ChargingProfile> profiles) {
+        EVLOG_info << "[";
+        for (auto& profile : profiles) {
+            EVLOG_info << "  ChargingProfile> " << utils::to_string(profile);
+        }
+        EVLOG_info << "]";
+    }
+
+    // Default values used within the tests
+    std::map<int32_t, std::unique_ptr<EvseInterface>> evses;
+    std::shared_ptr<DatabaseHandler> database_handler;
+
+    sqlite3* db_handle;
+
+    bool ignore_no_transaction = true;
+    std::shared_ptr<DeviceModel> device_model = create_device_model();
+    TestSmartChargingHandler handler = create_smart_charging_handler();
+    boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
+};
+
+/**
+ * Validates the SmartChargingHandler::determined_duraction and SmartChargingHandler::within_time_window
+ * utility functions.
+ */
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_DetermineDurationAndWithinTimeWindow) {
+    // Test 1: Start time before end time
+    {
+        DateTime start_time = ocpp::DateTime("2024-01-17T17:59:59");
+        DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+        int32_t duration = handler.determine_duration(start_time, end_time);
+
+        ASSERT_EQ(duration, 1);
+        ASSERT_TRUE(handler.within_time_window(start_time, end_time));
+    }
+
+    // Test 2 : Start time equals end time
+    {
+        DateTime start_time = ocpp::DateTime("2024-01-17T17:59:59");
+        DateTime end_time = ocpp::DateTime("2024-01-17T17:59:59");
+
+        int32_t duration = handler.determine_duration(start_time, end_time);
+        bool within_time_window = handler.within_time_window(start_time, end_time);
+
+        ASSERT_EQ(duration, 0);
+        ASSERT_FALSE(handler.within_time_window(start_time, end_time));
+    }
+
+    // Test 3: Start time after end time
+    {
+        DateTime start_time = ocpp::DateTime("2024-01-17T18:00:00");
+        DateTime end_time = ocpp::DateTime("2024-01-17T17:59:59");
+
+        int32_t duration = handler.determine_duration(start_time, end_time);
+        bool within_time_window = handler.within_time_window(start_time, end_time);
+
+        ASSERT_EQ(duration, -1);
+        ASSERT_FALSE(handler.within_time_window(start_time, end_time));
+    }
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_GetProfileStartTime_KindAbsolute) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+    DateTime time = ocpp::DateTime("2024-01-17T17:59:59");
+    ChargingProfile profile = SmartChargingTestUtils::get_charging_profile_from_file("baseline/TxProfile_1.json");
+    DateTime expected = ocpp::DateTime("2024-01-17T18:00:00");
+
+    std::optional<ocpp::DateTime> actual = handler.get_profile_start_time(profile, time, DEFAULT_EVSE_ID);
+
+    ASSERT_EQ(expected, actual.value());
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_GetProfileStartTime_KindRecurring) {
+    GTEST_SKIP();
+    create_evse_with_id(DEFAULT_EVSE_ID);
+    DateTime time = ocpp::DateTime("2024-01-17T17:00:00");
+    ChargingProfile profile = SmartChargingTestUtils::get_charging_profile_from_file("baseline/TxProfile_100.json");
+    DateTime expected = ocpp::DateTime("2024-01-17T18:10:00");
+
+    std::optional<ocpp::DateTime> actual = handler.get_profile_start_time(profile, time, DEFAULT_EVSE_ID);
+
+    ASSERT_EQ(expected, actual.value());
+}
+
+// TODO: functionality currently not supported.
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_GetProfileStartTime_KindRelative) {
+    GTEST_SKIP();
+    // create_evse_with_id(DEFAULT_EVSE_ID);
+    // DateTime time = ocpp::DateTime("2024-01-17T18:00:00");
+    // ChargingProfile profile = getChargingProfileFromFile("TxProfile_100.json");
+    // DateTime expected = ocpp::DateTime("2024-01-17T18:10:00");
+
+    // std::optional<ocpp::DateTime> actual = handler.get_profile_start_time(profile, time, DEFAULT_EVSE_ID);
+
+    // ASSERT_EQ(expected, actual.value());
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_GetPeriodEndTime) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    // Test 1: Profile TxProfile_01.json, Absolute, Single Charging Period
+    const auto profile_01 = SmartChargingTestUtils::get_charging_profile_from_file("baseline/TxProfile_1.json");
+
+    const DateTime period_start_time_01 = ocpp::DateTime("2024-01-17T18:00:00");
+    const DateTime expected_period_end_time_01 = ocpp::DateTime("2024-01-17T18:18:00");
+    const ChargingSchedule schedule_01 = profile_01.chargingSchedule.front();
+
+    EVLOG_debug << "DURATION = " << utils::get_log_duration_string(schedule_01.duration.value());
+    DateTime actual_period_end_time_01 = handler.get_period_end_time(0, period_start_time_01, schedule_01);
+
+    ASSERT_EQ(expected_period_end_time_01, actual_period_end_time_01);
+
+    // Test 2: Profile TxProfile_100.json Period #1
+    const auto profile_100 = SmartChargingTestUtils::get_charging_profile_from_file("baseline/TxProfile_100.json");
+
+    const DateTime period_start_time_02 = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime expected_period_end_time_02 = ocpp::DateTime("2024-01-18T01:00:00");
+    const ChargingSchedule schedule_02 = profile_100.chargingSchedule.front();
+
+    EVLOG_debug << "DURATION = " << utils::get_log_duration_string(28800);
+    DateTime actual_period_end_time_02 = handler.get_period_end_time(0, period_start_time_02, schedule_02);
+
+    ASSERT_EQ(expected_period_end_time_02, actual_period_end_time_02);
+
+    // Test 2a: Profile TxProfile_100.json Period #1 - Start time 1 hour later than startSchedule. Not enforcing
+    // startSchedule as fixed time point for chargingSchedulePeriod calculations. TODO: overly complex, begging for
+    // defects logic matches 1.6. Refactoring opportunity? Probability of defect: LOW
+    // const DateTime period_start_time_02a = ocpp::DateTime("2024-01-17T18:00:00");
+    // DateTime actual_period_end_time_02a = handler.get_period_end_time(0, period_start_time_02a, schedule_02);
+    // ASSERT_EQ(expected_period_end_time_02, actual_period_end_time_02a);
+
+    // Test 3: Profile TxProfile_100.json Period #2
+    const DateTime period_start_time_03 = ocpp::DateTime("2024-01-18T13:00:00");
+    const DateTime expected_period_end_time_03 = ocpp::DateTime("2024-01-19T01:00:00");
+
+    EVLOG_debug << "DURATION = " << utils::get_log_duration_string(72000);
+    DateTime actual_period_end_time_03 = handler.get_period_end_time(1, period_start_time_03, schedule_02);
+
+    ASSERT_EQ(expected_period_end_time_03, actual_period_end_time_03);
+}
+
+// Based upon K01.FR11 K01.FR38
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_GetPeriodEndTime_PAIN) {
+    GTEST_SKIP();
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_GetNextTempTime) {
+    // GTEST_SKIP();
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    const DateTime time_17_17_59_59 = ocpp::DateTime("2024-01-17T17:59:59");
+    const DateTime time_17_18_18_00 = ocpp::DateTime("2024-01-17T18:18:00");
+    const DateTime time_18_01_00_00 = ocpp::DateTime("2024-01-18T01:00:00");
+    const DateTime time_18_02_00_00 = ocpp::DateTime("2024-01-18T02:00:00");
+    const DateTime time_18_13_00_00 = ocpp::DateTime("2024-01-18T13:00:00");
+    const DateTime time_18_17_00_00 = ocpp::DateTime("2024-01-18T17:00:00");
+    std::vector<ChargingProfile> profiles = SmartChargingTestUtils::get_baseline_profile_vector();
+
+    ASSERT_EQ(2, profiles.size());
+    ASSERT_EQ(time_17_18_18_00, handler.get_next_temp_time(time_17_17_59_59, profiles, DEFAULT_EVSE_ID));
+    ASSERT_EQ(time_18_01_00_00, handler.get_next_temp_time(time_17_18_18_00, profiles, DEFAULT_EVSE_ID));
+    ASSERT_EQ(time_18_13_00_00, handler.get_next_temp_time(time_18_02_00_00, profiles, DEFAULT_EVSE_ID));
+    ASSERT_EQ(time_18_17_00_00, handler.get_next_temp_time(time_18_13_00_00, profiles, DEFAULT_EVSE_ID));
+}
+
+/**
+ * Calculate Composite Schedule
+ */
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_ValidateBaselineProfileVector) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    const DateTime time_17_17_59_59 = ocpp::DateTime("2024-01-17T17:59:59");
+    const DateTime start_time = ocpp::DateTime("2024-01-17T18:01:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-18T06:00:00");
+    const int32_t expected_duration = 43140;
+
+    std::vector<ChargingProfile> profiles = SmartChargingTestUtils::get_baseline_profile_vector();
+
+    CompositeSchedule composite_schedule =
+        handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
+
+    EVLOG_info << "CompositeSchedule> " << utils::to_string(composite_schedule);
+
+    // Validate base fields
+    ASSERT_EQ(ChargingRateUnitEnum::W, composite_schedule.chargingRateUnit);
+    ASSERT_EQ(DEFAULT_EVSE_ID, composite_schedule.evseId);
+    ASSERT_EQ(expected_duration, composite_schedule.duration);
+    ASSERT_EQ(start_time, composite_schedule.scheduleStart);
+    ASSERT_EQ(composite_schedule.chargingSchedulePeriod.size(), 3);
+
+    // Validate each period
+    auto& period_01 = composite_schedule.chargingSchedulePeriod.at(0);
+    ASSERT_EQ(period_01.limit, 2000);
+    ASSERT_EQ(period_01.numberPhases, 1);
+    ASSERT_EQ(period_01.startPeriod, 0);
+    auto& period_02 = composite_schedule.chargingSchedulePeriod.at(1);
+    ASSERT_EQ(period_02.limit, 11000);
+    SmartChargingTestUtils utils;
+    std::vector<ChargingProfile> reverse_profiles = utils.get_baseline_profile_vector();
+}
+
+TEST_F(ChargepointTestFixtureV201, getChargingProfilesFromDirectory) {
+    std::vector<ChargingProfile> vic =
+        SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "baseline/");
+
+    std::string s = SmartChargingTestUtils::to_string(vic);
+    EVLOG_info << s;
+    EVLOG_info << "md5hash> " << SmartChargingTestUtils::md5hash(s);
+}
+
+} // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

Adding functionality for calculating composite schedule into OCPP 2.0.1 as well as unit tests
for OCPP 1.6 calculate enhanced composite schedule

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

