### PR TITLE
Updated FR45 to use supplyPhases

### DIFF
--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -302,6 +302,9 @@ ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const Char
 ProfileValidationResultEnum
 SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
                                                  std::optional<EvseInterface*> evse_opt) const {
+    auto charging_station_supply_phases =
+        this->device_model->get_value<int32_t>(ControllerComponentVariables::ChargingStationSupplyPhases);
+
     for (auto& schedule : profile.chargingSchedule) {
         // K01.FR.26; We currently need to do string conversions for this manually because our DeviceModel class does
         // not let us get a vector of ChargingScheduleChargingRateUnits.
@@ -355,7 +358,7 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
             if (phase_type == CurrentPhaseType::AC) {
                 // K01.FR.45; Once again rejecting invalid values
                 if (charging_schedule_period.numberPhases.has_value() &&
-                    charging_schedule_period.numberPhases > DEFAULT_AND_MAX_NUMBER_PHASES) {
+                    charging_schedule_period.numberPhases > charging_station_supply_phases) {
                     return ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedNumberPhases;
                 }
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -686,7 +686,11 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCChargingStat
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR45_IfNumberPhasesGreaterThanMaxNumberPhasesForACEVSE_ThenProfileIsInvalid) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR45_IfNumberPhasesGreaterThanChargingStationSupplyPhasesForACEVSE_ThenProfileIsInvalid) {
+    device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
+                            ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
+                            AttributeEnum::Actual, std::to_string(0), "test", true);
     auto mock_evse = testing::NiceMock<EvseMock>();
     ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::AC));
 
@@ -701,7 +705,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR45_IfNumberPhasesGreaterThanMaxNumberPha
 }
 
 TEST_F(ChargepointTestFixtureV201,
-       K01FR45_IfNumberPhasesGreaterThanMaxNumberPhasesForACChargingStation_ThenProfileIsInvalid) {
+       K01FR45_IfNumberPhasesGreaterThanChargingStationSupplyPhasesForACChargingStation_ThenProfileIsInvalid) {
     device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
                             ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
                             AttributeEnum::Actual, std::to_string(1), "test", true);


### PR DESCRIPTION
## Describe your changes

Based on new findings, updated FR45 to use ChargingStation supplyPhases instead of DEFAULT_AND_MAX_NUMBER_PHASES

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

