### PR TITLE
composite_schedule: Add test cases for ChargingStationMaxProfile

### DIFF
--- a/tests/lib/ocpp/v201/json/max/ChargingStationMaxProfile_grid_hourly.json
+++ b/tests/lib/ocpp/v201/json/max/ChargingStationMaxProfile_grid_hourly.json
@@ -1,0 +1,138 @@
+{
+    "id": 24,
+    "chargingProfileKind": "Recurring",
+    "chargingProfilePurpose": "ChargingStationMaxProfile",
+    "chargingSchedule": [
+        {
+            "id": 0,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 10.0,
+                    "numberPhases": 1,
+                    "startPeriod": 0
+                },
+                {
+                    "limit": 20.0,
+                    "numberPhases": 1,
+                    "startPeriod": 3600
+                },
+                {
+                    "limit": 30.0,
+                    "numberPhases": 1,
+                    "startPeriod": 7200
+                },
+                {
+                    "limit": 40.0,
+                    "numberPhases": 1,
+                    "startPeriod": 10800
+                },
+                {
+                    "limit": 50.0,
+                    "numberPhases": 1,
+                    "startPeriod": 14400
+                },
+                {
+                    "limit": 60.0,
+                    "numberPhases": 1,
+                    "startPeriod": 18000
+                },
+                {
+                    "limit": 70.0,
+                    "numberPhases": 1,
+                    "startPeriod": 21600
+                },
+                {
+                    "limit": 80.0,
+                    "numberPhases": 1,
+                    "startPeriod": 25200
+                },
+                {
+                    "limit": 90.0,
+                    "numberPhases": 1,
+                    "startPeriod": 28800
+                },
+                {
+                    "limit": 100.0,
+                    "numberPhases": 1,
+                    "startPeriod": 32400
+                },
+                {
+                    "limit": 110.0,
+                    "numberPhases": 1,
+                    "startPeriod": 36000
+                },
+                {
+                    "limit": 120.0,
+                    "numberPhases": 1,
+                    "startPeriod": 39600
+                },
+                {
+                    "limit": 130.0,
+                    "numberPhases": 1,
+                    "startPeriod": 43200
+                },
+                {
+                    "limit": 140.0,
+                    "numberPhases": 1,
+                    "startPeriod": 46800
+                },
+                {
+                    "limit": 150.0,
+                    "numberPhases": 1,
+                    "startPeriod": 50400
+                },
+                {
+                    "limit": 160.0,
+                    "numberPhases": 1,
+                    "startPeriod": 54000
+                },
+                {
+                    "limit": 170.0,
+                    "numberPhases": 1,
+                    "startPeriod": 57600
+                },
+                {
+                    "limit": 180.0,
+                    "numberPhases": 1,
+                    "startPeriod": 61200
+                },
+                {
+                    "limit": 190.0,
+                    "numberPhases": 1,
+                    "startPeriod": 64800
+                },
+                {
+                    "limit": 200.0,
+                    "numberPhases": 1,
+                    "startPeriod": 68400
+                },
+                {
+                    "limit": 210.0,
+                    "numberPhases": 1,
+                    "startPeriod": 72000
+                },
+                {
+                    "limit": 220.0,
+                    "numberPhases": 1,
+                    "startPeriod": 75600
+                },
+                {
+                    "limit": 230.0,
+                    "numberPhases": 1,
+                    "startPeriod": 79200
+                },
+                {
+                    "limit": 240.0,
+                    "numberPhases": 1,
+                    "startPeriod": 82800
+                }
+            ],
+            "duration": 86400,
+            "minChargingRate": 0.0,
+            "startSchedule": "2024-01-17T00:00:00.000Z"
+        }
+    ],
+    "recurrencyKind": "Daily",
+    "stackLevel": 0
+}

--- a/tests/lib/ocpp/v201/json/max/README.md
+++ b/tests/lib/ocpp/v201/json/max/README.md
@@ -1,0 +1,8 @@
+# Max
+
+This scenario layers TxProfiles on top of a ChargingStationMaxProfile that has limits for all 24 hours.
+
+Used by:
+
+* `K08_CalculateCompositesSchedule_MaxOverridesHigherLimits`
+* `K08_CalculateCompositeSchedule_MaxOverridenByLowerLimits`

--- a/tests/lib/ocpp/v201/json/max/TXProfile_2000.json
+++ b/tests/lib/ocpp/v201/json/max/TXProfile_2000.json
@@ -1,0 +1,23 @@
+{
+    "id": 2000,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxProfile",
+    "chargingSchedule": [
+        {
+            "id": 0,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 2000.0,
+                    "numberPhases": 1,
+                    "startPeriod": 0
+                }
+            ],
+            "duration": 3600,
+            "minChargingRate": 0.0,
+            "startSchedule": "2024-01-17T00:00:00.000Z"
+        }
+    ],
+    "stackLevel": 0,
+    "transactionId": "fe380033-249d-4690-8dc0-f0a0d7842769"
+}

--- a/tests/lib/ocpp/v201/json/max/TXProfile_2001.json
+++ b/tests/lib/ocpp/v201/json/max/TXProfile_2001.json
@@ -1,0 +1,23 @@
+{
+    "id": 2001,
+    "chargingProfileKind": "Absolute",
+    "chargingProfilePurpose": "TxProfile",
+    "chargingSchedule": [
+        {
+            "id": 0,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 10.0,
+                    "numberPhases": 1,
+                    "startPeriod": 0
+                }
+            ],
+            "duration": 3600,
+            "minChargingRate": 0.0,
+            "startSchedule": "2024-01-17T23:00:00.000Z"
+        }
+    ],
+    "stackLevel": 1,
+    "transactionId": "fe380033-249d-4690-8dc0-f0a0d7842769"
+}

--- a/tests/lib/ocpp/v201/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v201/test_composite_schedule.cpp
@@ -560,4 +560,62 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_19
     ASSERT_EQ(actual, expected);
 }
 
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridesHigherLimits) {
+    std::vector<ChargingProfile> profiles =
+        SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/max/");
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T00:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T02:00:00");
+
+    CompositeSchedule expected = {
+        .chargingSchedulePeriod = {{
+                                       .startPeriod = 0,
+                                       .limit = 10.0,
+                                       .numberPhases = 1,
+                                   },
+                                   {
+                                       .startPeriod = 3600,
+                                       .limit = 20.0,
+                                       .numberPhases = 1,
+                                   }},
+        .evseId = DEFAULT_EVSE_ID,
+        .duration = 7200,
+        .scheduleStart = start_time,
+        .chargingRateUnit = ChargingRateUnitEnum::W,
+    };
+
+    CompositeSchedule actual =
+        handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridenByLowerLimits) {
+    std::vector<ChargingProfile> profiles =
+        SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/max/");
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T22:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-18T00:00:00");
+
+    CompositeSchedule expected = {
+        .chargingSchedulePeriod = {{
+                                       .startPeriod = 0,
+                                       .limit = 230.0,
+                                       .numberPhases = 1,
+                                   },
+                                   {
+                                       .startPeriod = 3600,
+                                       .limit = 10.0,
+                                       .numberPhases = 1,
+                                   }},
+        .evseId = DEFAULT_EVSE_ID,
+        .duration = 7200,
+        .scheduleStart = start_time,
+        .chargingRateUnit = ChargingRateUnitEnum::W,
+    };
+
+    CompositeSchedule actual =
+        handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
+    ASSERT_EQ(actual, expected);
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

Test that:

* `ChargingStationMaxProfile`s overrride profiles with higher limits...
* ...and are overriden by profiles with lower limits

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

