### PR TITLE
K01.FR.29 Smart Charging not supported/enabled

### DIFF
--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -16,7 +16,6 @@
             }
         }
     },
-
     {
         "name": "Connector",
         "evse_id": 1,
@@ -774,6 +773,12 @@
                 "variable_name": "RateUnit",
                 "attributes": {
                     "Actual": ""
+                }
+            },
+            "SmartChargingCtrlrAvailable": {
+                "variable_name": "Available",
+                "attributes": {
+                    "Actual": true
                 }
             },
             "SmartChargingCtrlrAvailableEnabled": {

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -784,7 +784,7 @@
             "SmartChargingCtrlrAvailableEnabled": {
                 "variable_name": "Enabled",
                 "attributes": {
-                    "Actual": false
+                    "Actual": true
                 }
             }
         }

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1254,7 +1254,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K01.FR.26 | ✅     |                                                                                                 |
 | K01.FR.27 | ✅     |                                                                                                 |
 | K01.FR.28 | ✅     |                                                                                                 |
-| K01.FR.29 |        |                                                                                                 |
+| K01.FR.29 | ✅     |                                                                                                 |
 | K01.FR.30 |        |                                                                                                 |
 | K01.FR.31 |        |                                                                                                 |
 | K01.FR.32 | ✅     |                                                                                                 |

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3271,7 +3271,7 @@ void ChargePoint::handle_set_charging_profile_req(Call<SetChargingProfileRequest
 
     // K01.FR.29: Reject if SmartCharging is not available for this Charging Station
     bool is_charging_station_enable =
-        this->device_model->get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrAvailable)
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrAvailableEnabled)
             .value_or(false);
 
     if (!is_charging_station_enable) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3269,6 +3269,21 @@ void ChargePoint::handle_set_charging_profile_req(Call<SetChargingProfileRequest
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatusEnum::Rejected;
 
+    // K01.FR.29: Reject if SmartCharging is not available for this Charging Station
+    bool is_charging_station_enable =
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrAvailable)
+            .value_or(false);
+
+    if (!is_charging_station_enable) {
+        EVLOG_warning << "SmartChargingCtrlrAvailable is not set for Charging Station. Returning NotSupported error";
+
+        const auto call_error =
+            CallError(call.uniqueId, "NotSupported", "Charging Station does not support smart charging", json({}));
+        this->send(call_error);
+
+        return;
+    }
+
     // K01.FR.22: Reject ChargingStationExternalConstraints profiles in SetChargingProfileRequest
     if (msg.chargingProfile.chargingProfilePurpose == ChargingProfilePurposeEnum::ChargingStationExternalConstraints) {
         response.statusInfo = StatusInfo();

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -711,4 +711,49 @@ TEST_F(ChargePointFixture, K01FR22_SetChargingProfileRequest_RejectsChargingStat
     charge_point->handle_message(set_charging_profile_req);
 }
 
+/// This test ensures that when Smart Charging isn't available it doesn't process the submitted profile.
+///
+/// This test is disabled because it only passes if the ControllerComponentVariables::SmartChargingCtrlrAvailable
+/// entry is removed from the config/v201/config.json file.
+TEST_F(ChargePointFixture, DISABLED_K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError) {
+    auto evse_connector_structure = create_evse_connector_structure();
+    auto database_handler = create_database_handler();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    configure_callbacks_with_mocks();
+
+    const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
+    std::shared_ptr<MessageQueue<v201::MessageType>> message_queue =
+        std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+            [this](json message) -> bool { return false; },
+            MessageQueueConfig{
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageAttempts),
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageAttemptInterval),
+                this->device_model->get_optional_value<int>(ControllerComponentVariables::MessageQueueSizeThreshold)
+                    .value_or(DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD),
+                this->device_model->get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages)
+                    .value_or(false),
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageTimeout)},
+            database_handler);
+
+    ocpp::v201::ChargePoint chargePoint(evse_connector_structure, device_model, database_handler, message_queue, "/tmp",
+                                        evse_security, callbacks);
+
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    SetChargingProfileRequest req;
+    req.evseId = DEFAULT_EVSE_ID;
+    req.chargingProfile = profile;
+
+    auto set_charging_profile_req =
+        request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
+
+    EXPECT_CALL(*smart_charging_handler, validate_profile(testing::_, testing::_)).Times(0);
+
+    charge_point->handle_message(set_charging_profile_req);
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

This card specifically addresses requirement K01.FR.29 from the OCPP 2.0.1 Edition 2 specification:

    When Charging Station does not support smart charging.

    Charging Station SHALL respond with RPC Framework CALLERROR: NotSupported.

This is done by checking if the `SmartChargingCtrlrAvailableEnabled` is set in the Charging Stations configuration when a Smart Charging request is made. 

This Controller Component Variable is set in the `SmartChargingCtrlr` section of the `config.json` used for the Charging Station. 

Enabling Smart Charging is done by adding the following to the `SmartChargingCtrlr` section of the `config.json` 
used for the Charging Station:

```json
"SmartChargingCtrlrAvailableEnabled": {
    "variable_name": "Enabled",
    "attributes": {
        "Actual": true
    }
},
```

The sample used for testing within the liboccp codebase is located at `config/v201/config.json`.

If the value is either set to `false`, or the Component is not present in the DeviceModel's `config.json`, the Charging Station will immediately return a `NotSupported` Call Error.

### Testing

The unit test for this functionality is named `DISABLED_K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError`.
For expedience sake, the test is disabled. It will only pass if one of the steps outlined above is taken to configure the system to not support Smart Charging, which in turn will cause other tests in the suite to fail.

While we do want to take the time to find a permanent, it was decided that this could be done at a later date after our deadlines are met. 

In order to run the test quickly, remove `DISABLED_` from the unit test name, and update the entry in the build directory's `build/tests/resources/example_config/v201/config.json` file.

## Issue ticket number and link

[170](https://github.com/US-JOET/base-camp/issues/170)

## Checklist before requesting a review
- [✅] I have performed a self-review of my code
- [  ] I have made corresponding changes to the documentation
- [✅] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [✅] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

