### PR TITLE
K08 defect #177 profile sort

### DIFF
--- a/tests/lib/ocpp/v201/smart_charging_test_utils.hpp
+++ b/tests/lib/ocpp/v201/smart_charging_test_utils.hpp
@@ -52,6 +52,10 @@ public:
             }
         }
 
+        // Sort profiles by id in ascending order
+        std::sort(profiles.begin(), profiles.end(),
+                  [](const ChargingProfile& a, const ChargingProfile& b) { return a.id < b.id; });
+
         EVLOG_debug << "get_charging_profiles_from_directory END";
         return profiles;
     }


### PR DESCRIPTION
## Describe your changes

The ordering of the Profiles in the vector returned from `SmartChargingTestUtils::get_charging_profiles_from_directory()` is not consistent on CI GitHub Action for libocpp creating floppy tests. You can see an example of this behavior [here](https://github.com/US-JOET/libocpp/actions/runs/10319811947). 

For this we have added a sort of the vector in the function before it is passed to the test:

```cpp
std::sort(profiles.begin(), profiles.end(),
    [](const ChargingProfile& a, const ChargingProfile& b) { return a.id < b.id; });
```

## Issue ticket number and link

[https://github.com/US-JOET/base-camp/issues/177](https://github.com/US-JOET/base-camp/issues/177)

## Checklist before requesting a review
- [✅] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [✅] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

