### PR TITLE
Add get_valid_proflies() to SmartChargingHandler

### DIFF
--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -128,6 +128,11 @@ public:
     std::vector<ChargingProfile> get_profiles() const;
 
     ///
+    /// \brief Retrieves all profiles that should be considered for calculating the composite schedule.
+    ///
+    std::vector<ChargingProfile> get_valid_profiles(int32_t evse_id);
+
+    ///
     /// \brief Calculates the composite schedule for the given \p valid_profiles and the given \p connector_id
     ///
     CompositeSchedule calculate_composite_schedule(std::vector<ChargingProfile>& valid_profiles,
@@ -195,6 +200,7 @@ private:
     std::vector<ChargingProfile> get_station_wide_profiles() const;
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
+    std::vector<ChargingProfile> get_valid_profiles_for_evse(int32_t evse_id);
     void conform_validity_periods(ChargingProfile& profile) const;
     CurrentPhaseType get_current_phase_type(const std::optional<EvseInterface*> evse_opt) const;
     CompositeSchedule initialize_composite_schedule(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time,

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -437,6 +437,32 @@ std::vector<ChargingProfile> SmartChargingHandler::get_profiles() const {
     return all_profiles;
 }
 
+std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles_for_evse(int32_t evse_id) {
+    std::vector<ChargingProfile> valid_profiles;
+
+    if (charging_profiles.count(evse_id) > 0) {
+        auto& evse_profiles = this->charging_profiles.at(evse_id);
+        for (auto profile : evse_profiles) {
+            if (this->validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid) {
+                valid_profiles.push_back(profile);
+            }
+        }
+    }
+
+    return valid_profiles;
+}
+
+std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles(int32_t evse_id) {
+    std::vector<ChargingProfile> valid_profiles = get_valid_profiles_for_evse(evse_id);
+
+    if (evse_id != STATION_WIDE_ID) {
+        auto station_wide_profiles = get_valid_profiles_for_evse(STATION_WIDE_ID);
+        valid_profiles.insert(valid_profiles.end(), station_wide_profiles.begin(), station_wide_profiles.end());
+    }
+
+    return valid_profiles;
+}
+
 std::vector<ChargingProfile> SmartChargingHandler::get_evse_specific_tx_default_profiles() const {
     std::vector<ChargingProfile> evse_specific_tx_default_profiles;
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -34,7 +34,7 @@
 
 namespace ocpp::v201 {
 
-static const int NR_OF_EVSES = 1;
+static const int NR_OF_EVSES = 2;
 static const int STATION_WIDE_ID = 0;
 static const int DEFAULT_EVSE_ID = 1;
 static const int DEFAULT_PROFILE_ID = 1;
@@ -205,6 +205,19 @@ protected:
             profile_id, ChargingProfilePurposeEnum::TxDefaultProfile, create_charge_schedule(ChargingRateUnitEnum::A),
             {}, ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, validFrom, validTo);
         handler.add_profile(existing_profile, evse_id);
+    }
+
+    std::optional<ChargingProfile> add_valid_profile_to(int evse_id, int profile_id) {
+        auto periods = create_charging_schedule_periods({0, 1, 2});
+        auto profile = create_charging_profile(
+            profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+            create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+        auto response = handler.validate_and_add_profile(profile, evse_id);
+        if (response.status == ChargingProfileStatusEnum::Accepted) {
+            return profile;
+        } else {
+            return {};
+        }
     }
 
     // Default values used within the tests
@@ -1166,6 +1179,67 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfNoProfiles_ThenNoValidProfilesReturned) {
+    auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
+    EXPECT_THAT(profiles, testing::IsEmpty());
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfEvseHasProfiles_ThenThoseProfilesReturned) {
+    auto profile = add_valid_profile_to(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
+    ASSERT_TRUE(profile.has_value());
+
+    auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
+    EXPECT_THAT(profiles, testing::Contains(profile));
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfOtherEvseHasProfiles_ThenThoseProfilesAreNotReturned) {
+    auto profile1 = add_valid_profile_to(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
+    ASSERT_TRUE(profile1.has_value());
+    auto profile2 = add_valid_profile_to(DEFAULT_EVSE_ID + 1, DEFAULT_PROFILE_ID + 1);
+    ASSERT_TRUE(profile2.has_value());
+
+    auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
+    EXPECT_THAT(profiles, testing::Contains(profile1));
+    EXPECT_THAT(profiles, testing::Not(testing::Contains(profile2)));
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfStationWideProfilesExist_ThenThoseProfilesAreReturned) {
+    auto profile = add_valid_profile_to(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
+    ASSERT_TRUE(profile.has_value());
+
+    auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
+    EXPECT_THAT(profiles, testing::Contains(profile));
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfStationWideProfilesExist_ThenThoseProfilesAreReturnedOnce) {
+    auto profile = add_valid_profile_to(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
+    ASSERT_TRUE(profile.has_value());
+
+    auto profiles = handler.get_valid_profiles(STATION_WIDE_ID);
+    EXPECT_THAT(profiles, testing::Contains(profile));
+    EXPECT_THAT(profiles.size(), testing::Eq(1));
+}
+
+TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfInvalidProfileExists_ThenThatProfileIsNotReturned) {
+    auto extraneous_start_schedule = ocpp::DateTime("2024-01-17T17:00:00");
+    auto periods = create_charging_schedule_periods(0);
+    auto invalid_profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A, periods, extraneous_start_schedule),
+                                DEFAULT_TX_ID, ChargingProfileKindEnum::Relative, 1);
+    handler.add_profile(invalid_profile, DEFAULT_EVSE_ID);
+
+    auto invalid_station_wide_profile =
+        create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A, periods, extraneous_start_schedule),
+                                DEFAULT_TX_ID, ChargingProfileKindEnum::Relative, 1);
+    handler.add_profile(invalid_station_wide_profile, STATION_WIDE_ID);
+
+    auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
+    EXPECT_THAT(profiles, testing::Not(testing::Contains(invalid_profile)));
+    EXPECT_THAT(profiles, testing::Not(testing::Contains(invalid_station_wide_profile)));
 }
 
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

get_valid_profiles() now returns all station-wide profiles and EVSE-specific profiles 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

