### PR TITLE
smart_charging: Add test for K04.FR.01

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1310,7 +1310,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark                                           |
 |-----------|--------|--------------------------------------------------|
-| K04.FR.01 |        |                                                  |
+| K04.FR.01 | ✅     |                                                  |
 | K04.FR.02 |        |                                                  |
 | K04.FR.03 | ✅     |                                                  |
 | K04.FR.04 |        | The same as K01.FR.21                            |

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -147,6 +147,11 @@ protected:
     ///
     ProfileValidationResultEnum verify_no_conflicting_external_constraints_id(const ChargingProfile& profile) const;
 
+    ///
+    /// \brief Retrieves existing profiles on the EVSE \p evse_id
+    ///
+    std::vector<ChargingProfile> get_profiles_on_evse(int32_t evse_id) const;
+
 private:
     std::vector<ChargingProfile> get_station_wide_profiles() const;
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -436,6 +436,14 @@ std::vector<ChargingProfile> SmartChargingHandler::get_profiles() const {
     return all_profiles;
 }
 
+std::vector<ChargingProfile> SmartChargingHandler::get_profiles_on_evse(int32_t evse_id) const {
+    std::vector<ChargingProfile> profiles;
+    if (charging_profiles.count(evse_id)) {
+        profiles = charging_profiles.at(evse_id);
+    }
+    return profiles;
+}
+
 std::vector<ChargingProfile> SmartChargingHandler::get_evse_specific_tx_default_profiles() const {
     std::vector<ChargingProfile> evse_specific_tx_default_profiles;
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -418,14 +418,7 @@ SetChargingProfileResponse SmartChargingHandler::add_profile(ChargingProfile& pr
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_station_wide_profiles() const {
-    std::vector<ChargingProfile> station_wide_profiles;
-    if (charging_profiles.count(STATION_WIDE_ID) > 0) {
-        station_wide_profiles = charging_profiles.at(STATION_WIDE_ID);
-    } else {
-        station_wide_profiles = {};
-    }
-
-    return station_wide_profiles;
+    return this->get_profiles_on_evse(STATION_WIDE_ID);
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_profiles() const {

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -46,6 +46,7 @@ const static std::string DEVICE_MODEL_DB_IN_MEMORY_PATH = "file::memory:?cache=s
 
 class TestSmartChargingHandler : public SmartChargingHandler {
 public:
+    using SmartChargingHandler::get_profiles_on_evse;
     using SmartChargingHandler::validate_charging_station_max_profile;
     using SmartChargingHandler::validate_evse_exists;
     using SmartChargingHandler::validate_profile_schedules;
@@ -1127,6 +1128,30 @@ TEST_F(ChargepointTestFixtureV201,
 
     EXPECT_THAT(profiles, testing::Contains(profile4));
     EXPECT_THAT(profiles, testing::Contains(profile5));
+}
+
+TEST_F(ChargepointTestFixtureV201, K04FR01_AddProfile_OnlyAddsToOneEVSE) {
+    auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+    auto profile2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
+                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+
+    auto response = handler.add_profile(profile1, DEFAULT_EVSE_ID);
+    auto response2 = handler.add_profile(profile2, DEFAULT_EVSE_ID + 1);
+
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(response2.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto sut1 = handler.get_profiles_on_evse(DEFAULT_EVSE_ID);
+    auto sut2 = handler.get_profiles_on_evse(DEFAULT_EVSE_ID + 1);
+
+    EXPECT_THAT(sut1, testing::Contains(profile1));
+    EXPECT_THAT(sut1, testing::Not(testing::Contains(profile2)));
+
+    EXPECT_THAT(sut2, testing::Contains(profile2));
+    EXPECT_THAT(sut2, testing::Not(testing::Contains(profile1)));
 }
 
 TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidProfiles) {


### PR DESCRIPTION
## Describe your changes

K04.FR.01 states that charging schedules should be managed per EVSE. This PR adds a test (and a helper function, `get_profiles_on_evse()`) to verify that profiles are EVSE-specific are only applied to that EVSE. We also use this helper in older methods where applicable.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

