### PR TITLE
K02FR05 - Delete TxProfiles by transaction ID after transaction ends.

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1286,7 +1286,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K02.FR.02 | ❎     | This should be handled by the user of `libocpp`. |
 | K02.FR.03 | ❎     |                                                  |
 | K02.FR.04 |        |                                                  |
-| K02.FR.05 |        |                                                  |
+| K02.FR.05 | ✅     |                                                  |
 | K02.FR.06 |        | The same as K01.FR.21                            |
 | K02.FR.07 |        | The same as K01.FR.22                            |
 | K02.FR.08 |        |                                                  |

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -70,6 +70,8 @@ public:
         ChargingProfile& profile, int32_t evse_id,
         AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
 
+    virtual void delete_transaction_tx_profiles(const std::string& transaction_id) = 0;
+
     virtual ProfileValidationResultEnum
     validate_profile(ChargingProfile& profile, int32_t evse_id,
                      AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
@@ -91,6 +93,8 @@ private:
 public:
     SmartChargingHandler(EvseManagerInterface& evse_manager, std::shared_ptr<DeviceModel>& device_model,
                          std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler);
+
+    void delete_transaction_tx_profiles(const std::string& transaction_id) override;
 
     ///
     /// \brief validates the given \p profile according to the specification,

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -467,6 +467,8 @@ void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime&
                                 trigger_reason, enhanced_transaction->get_seq_no(), std::nullopt, std::nullopt,
                                 transaction_id_token, meter_values, std::nullopt, this->is_offline(), std::nullopt);
 
+    // K02.FR.05 The transaction is over, so delete the TxProfiles associated with the transaction.
+    smart_charging_handler->delete_transaction_tx_profiles(enhanced_transaction->get_transaction().transactionId);
     evse_handle.release_transaction();
 
     bool send_reset = false;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -13,6 +13,7 @@
 #include "ocpp/v201/ocpp_types.hpp"
 #include "ocpp/v201/transaction.hpp"
 #include <algorithm>
+#include <cstring>
 #include <iterator>
 #include <ocpp/v201/smart_charging.hpp>
 #include <optional>
@@ -142,6 +143,20 @@ SmartChargingHandler::SmartChargingHandler(EvseManagerInterface& evse_manager,
                                            std::shared_ptr<DeviceModel>& device_model,
                                            std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler) :
     evse_manager(evse_manager), device_model(device_model), database_handler(database_handler) {
+}
+
+void SmartChargingHandler::delete_transaction_tx_profiles(const std::string& transaction_id) {
+    for (auto& [evse_id, profiles] : charging_profiles) {
+        auto iter = profiles.begin();
+        while (iter != profiles.end()) {
+            if (transaction_id.compare(iter->transactionId.value()) == 0) {
+                this->database_handler->delete_charging_profile(iter->id);
+                iter = profiles.erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+    }
 }
 
 SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -15,6 +15,7 @@ public:
                 (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
     MOCK_METHOD(ProfileValidationResultEnum, validate_profile,
                 (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
+    MOCK_METHOD(void, delete_transaction_tx_profiles, (const std::string& transaction_id));
     MOCK_METHOD(SetChargingProfileResponse, add_profile, (ChargingProfile & profile, int32_t evse_id));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -87,6 +87,11 @@ public:
         return device_model;
     }
 
+    std::shared_ptr<DatabaseHandler> create_database_handler() {
+        auto database_connection = std::make_unique<common::DatabaseConnection>(fs::path("/tmp/ocpp201") / "cp.db");
+        return std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V201);
+    }
+
     std::unique_ptr<TestChargePoint> create_charge_point() {
         std::map<int32_t, int32_t> evse_connector_structure = {{1, 1}, {2, 1}};
         std::unique_ptr<DeviceModelStorage> device_model_storage =
@@ -693,6 +698,27 @@ TEST_F(ChargePointFixture,
     EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(0);
 
     charge_point->handle_message(start_transaction_req);
+}
+
+TEST_F(ChargePointFixture, K02FR05_TransactionEnds_WillDeleteTxProfilesWithTransactionID) {
+    auto database_handler = create_database_handler();
+    database_handler->open_connection();
+    const auto cv = ControllerComponentVariables::ResumeTransactionsOnBoot;
+    this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "TEST", true);
+    int32_t connector_id = 1;
+    std::string session_id = "some-session-id";
+    ocpp::DateTime timestamp("2024-01-17T17:00:00");
+
+    charge_point->on_transaction_started(DEFAULT_EVSE_ID, connector_id, session_id, timestamp,
+                                         ocpp::v201::TriggerReasonEnum::Authorized, MeterValue(), {}, {}, {}, {},
+                                         ChargingStateEnum::EVConnected);
+    auto transaction = database_handler->transaction_get(DEFAULT_EVSE_ID);
+    ASSERT_THAT(transaction, testing::NotNull());
+
+    EXPECT_CALL(*smart_charging_handler,
+                delete_transaction_tx_profiles(transaction->get_transaction().transactionId.get()));
+    charge_point->on_transaction_finished(DEFAULT_EVSE_ID, timestamp, MeterValue(), ReasonEnum::StoppedByEV,
+                                          TriggerReasonEnum::StopAuthorized, {}, {}, ChargingStateEnum::EVConnected);
 }
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1201,7 +1201,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesTxProfilesByTransactionId) {
+TEST_F(ChargepointTestFixtureV201, K02FR05_DeleteTransactionTxProfiles_DeletesTxProfilesByTransactionId) {
     auto transaction_id = uuid();
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -1219,7 +1219,7 @@ TEST_F(ChargepointTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesT
 }
 
 TEST_F(ChargepointTestFixtureV201,
-       K02FR05_SmartChargingTransactionEnds_DoesNotDeleteTxProfilesWithDifferentTransactionId) {
+       K02FR05_DeleteTransactionTxProfiles_DoesNotDeleteTxProfilesWithDifferentTransactionId) {
     auto transaction_id = uuid();
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
     auto other_transaction_id = uuid();

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1201,4 +1201,42 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 
+TEST_F(ChargepointTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesTxProfilesByTransactionId) {
+    auto transaction_id = uuid();
+    this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A,
+                                                                  create_charging_schedule_periods({0, 1, 2}),
+                                                                  ocpp::DateTime("2024-01-17T17:00:00")),
+                                           transaction_id);
+
+    auto response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    handler.delete_transaction_tx_profiles(transaction_id);
+
+    EXPECT_THAT(handler.get_profiles(), testing::IsEmpty());
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K02FR05_SmartChargingTransactionEnds_DoesNotDeleteTxProfilesWithDifferentTransactionId) {
+    auto transaction_id = uuid();
+    this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
+    auto other_transaction_id = uuid();
+    this->evse_manager->open_transaction(DEFAULT_EVSE_ID, other_transaction_id);
+
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A,
+                                                                  create_charging_schedule_periods({0, 1, 2}),
+                                                                  ocpp::DateTime("2024-01-17T17:00:00")),
+                                           other_transaction_id);
+
+    auto response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    handler.delete_transaction_tx_profiles(transaction_id);
+
+    EXPECT_THAT(handler.get_profiles().size(), testing::Eq(1));
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
When a transaction ends, we shall delete TxProfiles associated with the transaction.


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

