### PR TITLE
Update ChargePoint tests to use new constructor with dependency injection.

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -148,6 +148,9 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
     v2g_certificate_expiration_check_timer([this]() { this->scheduled_check_v2g_certificate_expiration(); }),
     callbacks(callbacks),
     stop_auth_cache_cleanup_handler(false) {
+    EVLOG_info << "This ChargePoint constructor should no longer be used in favor of the one that allows for "
+                  "dependency injection";
+
     // Make sure the received callback struct is completely filled early before we actually start running
     if (!this->callbacks.all_callbacks_valid()) {
         EVLOG_AND_THROW(std::invalid_argument("All non-optional callbacks must be supplied"));

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -34,35 +34,11 @@ static const std::string DEFAULT_TX_ID = "10c75ff7-74f5-44f5-9d01-f649f3ac7b78";
 
 namespace ocpp::v201 {
 
-class TestChargePoint : public ChargePoint {
+class ChargePointCommonTestFixtureV201 : public DatabaseTestingUtils {
 public:
-    using ChargePoint::handle_message;
-    using ChargePoint::smart_charging_handler;
-
-    TestChargePoint(std::map<int32_t, int32_t>& evse_connector_structure,
-                    std::unique_ptr<DeviceModelStorage> device_model_storage, const std::string& ocpp_main_path,
-                    const std::string& core_database_path, const std::string& sql_init_path,
-                    const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
-                    const Callbacks& callbacks, std::shared_ptr<SmartChargingHandlerInterface> smart_charging_handler) :
-        ChargePoint(evse_connector_structure, std::move(device_model_storage), ocpp_main_path, core_database_path,
-                    sql_init_path, message_log_path, evse_security, callbacks) {
-        this->smart_charging_handler = smart_charging_handler;
+    ChargePointCommonTestFixtureV201() : device_model(create_device_model()) {
     }
-};
-
-class ChargePointFixture : public DatabaseTestingUtils {
-public:
-    ChargePointFixture() {
-    }
-    ~ChargePointFixture() {
-    }
-
-    void SetUp() override {
-        charge_point->start();
-    }
-
-    void TearDown() override {
-        charge_point->stop();
+    ~ChargePointCommonTestFixtureV201() {
     }
 
     std::map<int32_t, int32_t> create_evse_connector_structure() {
@@ -92,17 +68,6 @@ public:
                                 AttributeEnum::Actual, ac_phase_switching_supported.value_or(""), "test", true);
 
         return device_model;
-    }
-
-    std::unique_ptr<TestChargePoint> create_charge_point() {
-        std::map<int32_t, int32_t> evse_connector_structure = {{1, 1}, {2, 1}};
-        std::unique_ptr<DeviceModelStorage> device_model_storage =
-            std::make_unique<DeviceModelStorageSqlite>(DEVICE_MODEL_DB_IN_MEMORY_PATH);
-        auto charge_point = std::make_unique<TestChargePoint>(evse_connector_structure, std::move(device_model_storage),
-                                                              "", TEMP_OUTPUT_PATH, MIGRATION_FILES_LOCATION_V201,
-                                                              TEMP_OUTPUT_PATH, std::make_shared<EvseSecurityMock>(),
-                                                              create_callbacks_with_mocks(), smart_charging_handler);
-        return charge_point;
     }
 
     std::vector<ChargingSchedulePeriod> create_charging_schedule_periods(std::vector<int32_t> start_periods) {
@@ -158,32 +123,6 @@ public:
                                .transactionId = transaction_id};
     }
 
-    ocpp::v201::Callbacks create_callbacks_with_mocks() {
-        ocpp::v201::Callbacks callbacks;
-
-        callbacks.is_reset_allowed_callback = is_reset_allowed_callback_mock.AsStdFunction();
-        callbacks.reset_callback = reset_callback_mock.AsStdFunction();
-        callbacks.stop_transaction_callback = stop_transaction_callback_mock.AsStdFunction();
-        callbacks.pause_charging_callback = pause_charging_callback_mock.AsStdFunction();
-        callbacks.connector_effective_operative_status_changed_callback =
-            connector_effective_operative_status_changed_callback_mock.AsStdFunction();
-        callbacks.get_log_request_callback = get_log_request_callback_mock.AsStdFunction();
-        callbacks.unlock_connector_callback = unlock_connector_callback_mock.AsStdFunction();
-        callbacks.remote_start_transaction_callback = remote_start_transaction_callback_mock.AsStdFunction();
-        callbacks.is_reservation_for_token_callback = is_reservation_for_token_callback_mock.AsStdFunction();
-        callbacks.update_firmware_request_callback = update_firmware_request_callback_mock.AsStdFunction();
-        callbacks.security_event_callback = security_event_callback_mock.AsStdFunction();
-        callbacks.set_charging_profiles_callback = set_charging_profiles_callback_mock.AsStdFunction();
-
-        return callbacks;
-    }
-
-    sqlite3* db_handle;
-    std::shared_ptr<DeviceModel> device_model = create_device_model();
-    std::shared_ptr<SmartChargingHandlerMock> smart_charging_handler = std::make_shared<SmartChargingHandlerMock>();
-    std::unique_ptr<TestChargePoint> charge_point = create_charge_point();
-    boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
-
     std::shared_ptr<DatabaseHandler> create_database_handler() {
         auto database_connection = std::make_unique<common::DatabaseConnection>(fs::path("/tmp/ocpp201") / "cp.db");
         return std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V201);
@@ -222,6 +161,449 @@ public:
         callbacks.set_charging_profiles_callback = set_charging_profiles_callback_mock.AsStdFunction();
     }
 
+    std::shared_ptr<DeviceModel> device_model;
+
+    testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
+        is_reset_allowed_callback_mock;
+    testing::MockFunction<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
+        reset_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id, const ReasonEnum& stop_reason)> stop_transaction_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id)> pause_charging_callback_mock;
+    testing::MockFunction<void(const int32_t evse_id, const int32_t connector_id,
+                               const OperationalStatusEnum new_status)>
+        connector_effective_operative_status_changed_callback_mock;
+    testing::MockFunction<GetLogResponse(const GetLogRequest& request)> get_log_request_callback_mock;
+    testing::MockFunction<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)>
+        unlock_connector_callback_mock;
+    testing::MockFunction<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)>
+        remote_start_transaction_callback_mock;
+    testing::MockFunction<bool(const int32_t evse_id, const CiString<36> idToken,
+                               const std::optional<CiString<36>> groupIdToken)>
+        is_reservation_for_token_callback_mock;
+    testing::MockFunction<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)>
+        update_firmware_request_callback_mock;
+    testing::MockFunction<void(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info)>
+        security_event_callback_mock;
+    testing::MockFunction<void()> set_charging_profiles_callback_mock;
+    ocpp::v201::Callbacks callbacks;
+};
+
+/*
+ * K01.FR.02 states
+ *
+ *     "The CSMS MAY send a new charging profile for the EVSE that SHALL be used
+ *      as a limit schedule for the EV."
+ *
+ * When using libocpp, a charging station is notified of a new charging profile
+ * by means of the set_charging_profiles_callback. In order to ensure that a new
+ * profile can be immediately "used as a limit schedule for the EV", a
+ * valid set_charging_profiles_callback must be provided.
+ *
+ * As part of testing that K01.FR.02 is met, we provide the following tests that
+ * confirm an OCPP 2.0.1 ChargePoint with smart charging enabled will only
+ * consider its collection of callbacks valid if set_charging_profiles_callback
+ * is provided.
+ */
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.set_charging_profiles_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+/*
+ * For completeness, we also test that all other callbacks are checked by
+ * all_callbacks_valid.
+ */
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksAreInvalidWhenNotProvided) {
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksAreValidWhenAllRequiredCallbacksProvided) {
+    configure_callbacks_with_mocks();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.is_reset_allowed_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfResetCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.reset_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfStopTransactionCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.stop_transaction_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfPauseChargingCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.pause_charging_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.connector_effective_operative_status_changed_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfGetLogRequestCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.get_log_request_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.unlock_connector_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.remote_start_transaction_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.is_reservation_for_token_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.update_firmware_request_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfSecurityEventCallbackExists) {
+    configure_callbacks_with_mocks();
+    callbacks.security_event_callback = nullptr;
+
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.variable_changed_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const SetVariableData& set_variable_data)> variable_changed_callback_mock;
+    callbacks.variable_changed_callback = variable_changed_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.validate_network_profile_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<SetNetworkProfileStatusEnum(const int32_t configuration_slot,
+                                                      const NetworkConnectionProfile& network_connection_profile)>
+        validate_network_profile_callback_mock;
+    callbacks.validate_network_profile_callback = validate_network_profile_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.configure_network_connection_profile_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<bool(const NetworkConnectionProfile& network_connection_profile)>
+        configure_network_connection_profile_callback_mock;
+    callbacks.configure_network_connection_profile_callback =
+        configure_network_connection_profile_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.time_sync_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const ocpp::DateTime& currentTime)> time_sync_callback_mock;
+    callbacks.time_sync_callback = time_sync_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.boot_notification_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const ocpp::v201::BootNotificationResponse& response)> boot_notification_callback_mock;
+    callbacks.boot_notification_callback = boot_notification_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.ocpp_messages_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const std::string& message, MessageDirection direction)> ocpp_messages_callback_mock;
+    callbacks.ocpp_messages_callback = ocpp_messages_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalCSEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.cs_effective_operative_status_changed_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const OperationalStatusEnum new_status)>
+        cs_effective_operative_status_changed_callback_mock;
+    callbacks.cs_effective_operative_status_changed_callback =
+        cs_effective_operative_status_changed_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalEvseEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.evse_effective_operative_status_changed_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const int32_t evse_id, const OperationalStatusEnum new_status)>
+        evse_effective_operative_status_changed_callback_mock;
+    callbacks.evse_effective_operative_status_changed_callback =
+        evse_effective_operative_status_changed_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalGetCustomerInformationCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.get_customer_information_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<std::string(const std::optional<CertificateHashDataType> customer_certificate,
+                                      const std::optional<IdToken> id_token,
+                                      const std::optional<CiString<64>> customer_identifier)>
+        get_customer_information_callback_mock;
+    callbacks.get_customer_information_callback = get_customer_information_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalClearCustomerInformationCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.clear_customer_information_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<std::string(const std::optional<CertificateHashDataType> customer_certificate,
+                                      const std::optional<IdToken> id_token,
+                                      const std::optional<CiString<64>> customer_identifier)>
+        clear_customer_information_callback_mock;
+    callbacks.clear_customer_information_callback = clear_customer_information_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalAllConnectorsUnavailableCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.all_connectors_unavailable_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void()> all_connectors_unavailable_callback_mock;
+    callbacks.all_connectors_unavailable_callback = all_connectors_unavailable_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalDataTransferCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.data_transfer_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<DataTransferResponse(const DataTransferRequest& request)> data_transfer_callback_mock;
+    callbacks.data_transfer_callback = data_transfer_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalTransactionEventCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.transaction_event_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const TransactionEventRequest& transaction_event)> transaction_event_callback_mock;
+    callbacks.transaction_event_callback = transaction_event_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+TEST_F(ChargePointCommonTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalTransactionEventResponseCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.transaction_event_response_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid());
+
+    testing::MockFunction<void(const TransactionEventRequest& transaction_event,
+                               const TransactionEventResponse& transaction_event_response)>
+        transaction_event_response_callback_mock;
+    callbacks.transaction_event_response_callback = transaction_event_response_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid());
+}
+
+class ChargePointConstructorTestFixtureV201 : public ChargePointCommonTestFixtureV201 {
+public:
+    ChargePointConstructorTestFixtureV201() :
+        evse_connector_structure(create_evse_connector_structure()),
+        database_handler(create_database_handler()),
+        evse_security(std::make_shared<EvseSecurityMock>()) {
+    }
+    ~ChargePointConstructorTestFixtureV201() {
+    }
+
+    std::map<int32_t, int32_t> evse_connector_structure;
+    std::shared_ptr<DatabaseHandler> database_handler;
+    std::shared_ptr<EvseSecurityMock> evse_security;
+};
+
+TEST_F(ChargePointConstructorTestFixtureV201, CreateChargePoint) {
+    configure_callbacks_with_mocks();
+
+    EXPECT_NO_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler,
+                                            create_message_queue(database_handler), "/tmp", evse_security, callbacks));
+}
+
+TEST_F(ChargePointConstructorTestFixtureV201, CreateChargePoint_InitializeInCorrectOrder) {
+    database_handler->open_connection();
+    configure_callbacks_with_mocks();
+    auto message_queue = create_message_queue(database_handler);
+
+    const auto cv = ControllerComponentVariables::ResumeTransactionsOnBoot;
+    this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "TEST", true);
+
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A,
+                                                                  create_charging_schedule_periods({0, 1, 2}),
+                                                                  ocpp::DateTime("2024-01-17T17:00:00")),
+                                           DEFAULT_TX_ID);
+    database_handler->insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile);
+
+    ocpp::v201::ChargePoint charge_point(evse_connector_structure, device_model, database_handler, message_queue,
+                                         "/tmp", evse_security, callbacks);
+
+    EXPECT_NO_FATAL_FAILURE(charge_point.start(BootReasonEnum::PowerUp));
+
+    charge_point.stop();
+}
+
+TEST_F(ChargePointConstructorTestFixtureV201,
+       CreateChargePoint_EVSEConnectorStructureDefinedBadly_ThrowsDeviceModelStorageError) {
+    configure_callbacks_with_mocks();
+    auto evse_connector_structure = std::map<int32_t, int32_t>();
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler,
+                                         create_message_queue(database_handler), "/tmp", evse_security, callbacks),
+                 DeviceModelStorageError);
+}
+
+TEST_F(ChargePointConstructorTestFixtureV201, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArgument) {
+    configure_callbacks_with_mocks();
+    auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+        [this](json message) -> bool { return false; }, MessageQueueConfig<v201::MessageType>{}, database_handler);
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, nullptr, database_handler, message_queue, "/tmp",
+                                         evse_security, callbacks),
+                 std::invalid_argument);
+}
+
+TEST_F(ChargePointConstructorTestFixtureV201, CreateChargePoint_MissingDatabaseHandler_ThrowsInvalidArgument) {
+    configure_callbacks_with_mocks();
+    auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+        [this](json message) -> bool { return false; }, MessageQueueConfig<v201::MessageType>{}, nullptr);
+
+    auto database_handler = nullptr;
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
+                                         "/tmp", evse_security, callbacks),
+                 std::invalid_argument);
+}
+
+TEST_F(ChargePointConstructorTestFixtureV201, CreateChargePoint_CallbacksNotValid_ThrowsInvalidArgument) {
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler,
+                                         create_message_queue(database_handler), "/tmp", evse_security, callbacks),
+                 std::invalid_argument);
+}
+
+class TestChargePoint : public ChargePoint {
+public:
+    using ChargePoint::handle_message;
+    using ChargePoint::smart_charging_handler;
+
+    TestChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                    std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                    std::shared_ptr<MessageQueue<v201::MessageType>> message_queue, const std::string& message_log_path,
+                    const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks,
+                    std::shared_ptr<SmartChargingHandlerInterface> smart_charging_handler) :
+        ChargePoint(evse_connector_structure, device_model, database_handler, message_queue, message_log_path,
+                    evse_security, callbacks) {
+        this->smart_charging_handler = smart_charging_handler;
+    }
+};
+
+class ChargePointFunctionalityTestFixtureV201 : public ChargePointCommonTestFixtureV201 {
+public:
+    ChargePointFunctionalityTestFixtureV201() :
+        uuid_generator(boost::uuids::random_generator()),
+        smart_charging_handler(std::make_shared<SmartChargingHandlerMock>()),
+        charge_point(create_charge_point()) {
+    }
+    ~ChargePointFunctionalityTestFixtureV201() {
+    }
+
+    void SetUp() override {
+        charge_point->start();
+    }
+
+    void TearDown() override {
+        charge_point->stop();
+    }
+
     std::string uuid() {
         std::stringstream s;
         s << uuid_generator();
@@ -250,408 +632,21 @@ public:
         return enhanced_message;
     }
 
-    testing::MockFunction<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
-        is_reset_allowed_callback_mock;
-    testing::MockFunction<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
-        reset_callback_mock;
-    testing::MockFunction<void(const int32_t evse_id, const ReasonEnum& stop_reason)> stop_transaction_callback_mock;
-    testing::MockFunction<void(const int32_t evse_id)> pause_charging_callback_mock;
-    testing::MockFunction<void(const int32_t evse_id, const int32_t connector_id,
-                               const OperationalStatusEnum new_status)>
-        connector_effective_operative_status_changed_callback_mock;
-    testing::MockFunction<GetLogResponse(const GetLogRequest& request)> get_log_request_callback_mock;
-    testing::MockFunction<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)>
-        unlock_connector_callback_mock;
-    testing::MockFunction<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)>
-        remote_start_transaction_callback_mock;
-    testing::MockFunction<bool(const int32_t evse_id, const CiString<36> idToken,
-                               const std::optional<CiString<36>> groupIdToken)>
-        is_reservation_for_token_callback_mock;
-    testing::MockFunction<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)>
-        update_firmware_request_callback_mock;
-    testing::MockFunction<void(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info)>
-        security_event_callback_mock;
-    testing::MockFunction<void()> set_charging_profiles_callback_mock;
-    ocpp::v201::Callbacks callbacks;
+    std::unique_ptr<TestChargePoint> create_charge_point() {
+        auto database_handler = create_database_handler();
+        configure_callbacks_with_mocks();
+        auto charge_point = std::make_unique<TestChargePoint>(
+            create_evse_connector_structure(), device_model, database_handler, create_message_queue(database_handler),
+            TEMP_OUTPUT_PATH, std::make_shared<EvseSecurityMock>(), callbacks, smart_charging_handler);
+        return charge_point;
+    }
+
+    boost::uuids::random_generator uuid_generator;
+    std::shared_ptr<SmartChargingHandlerMock> smart_charging_handler;
+    std::unique_ptr<TestChargePoint> charge_point;
 };
 
-TEST_F(ChargePointFixture, CreateChargePoint) {
-    auto evse_connector_structure = create_evse_connector_structure();
-    auto database_handler = create_database_handler();
-    auto evse_security = std::make_shared<EvseSecurityMock>();
-    configure_callbacks_with_mocks();
-    auto message_queue = create_message_queue(database_handler);
-
-    EXPECT_NO_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
-                                            "/tmp", evse_security, callbacks));
-}
-
-TEST_F(ChargePointFixture, CreateChargePoint_InitializeInCorrectOrder) {
-    auto evse_connector_structure = create_evse_connector_structure();
-    auto database_handler = create_database_handler();
-    database_handler->open_connection();
-    auto evse_security = std::make_shared<EvseSecurityMock>();
-    configure_callbacks_with_mocks();
-    auto message_queue = create_message_queue(database_handler);
-
-    const auto cv = ControllerComponentVariables::ResumeTransactionsOnBoot;
-    this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "TEST", true);
-
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A,
-                                                                  create_charging_schedule_periods({0, 1, 2}),
-                                                                  ocpp::DateTime("2024-01-17T17:00:00")),
-                                           DEFAULT_TX_ID);
-    database_handler->insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile);
-
-    ocpp::v201::ChargePoint charge_point(evse_connector_structure, device_model, database_handler, message_queue,
-                                         "/tmp", evse_security, callbacks);
-
-    EXPECT_NO_FATAL_FAILURE(charge_point.start(BootReasonEnum::PowerUp));
-
-    charge_point.stop();
-}
-
-TEST_F(ChargePointFixture, CreateChargePoint_EVSEConnectorStructureDefinedBadly_ThrowsDeviceModelStorageError) {
-    auto database_handler = create_database_handler();
-    auto evse_security = std::make_shared<EvseSecurityMock>();
-    configure_callbacks_with_mocks();
-    auto message_queue = create_message_queue(database_handler);
-
-    auto evse_connector_structure = std::map<int32_t, int32_t>();
-
-    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
-                                         "/tmp", evse_security, callbacks),
-                 DeviceModelStorageError);
-}
-
-TEST_F(ChargePointFixture, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArgument) {
-    auto evse_connector_structure = create_evse_connector_structure();
-    auto database_handler = create_database_handler();
-    auto evse_security = std::make_shared<EvseSecurityMock>();
-    configure_callbacks_with_mocks();
-    auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
-        [this](json message) -> bool { return false; }, MessageQueueConfig<v201::MessageType>{}, database_handler);
-
-    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, nullptr, database_handler, message_queue, "/tmp",
-                                         evse_security, callbacks),
-                 std::invalid_argument);
-}
-
-TEST_F(ChargePointFixture, CreateChargePoint_MissingDatabaseHandler_ThrowsInvalidArgument) {
-    auto evse_connector_structure = create_evse_connector_structure();
-    auto evse_security = std::make_shared<EvseSecurityMock>();
-    configure_callbacks_with_mocks();
-    auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
-        [this](json message) -> bool { return false; }, MessageQueueConfig<v201::MessageType>{}, nullptr);
-
-    auto database_handler = nullptr;
-
-    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
-                                         "/tmp", evse_security, callbacks),
-                 std::invalid_argument);
-}
-
-TEST_F(ChargePointFixture, CreateChargePoint_CallbacksNotValid_ThrowsInvalidArgument) {
-    auto evse_connector_structure = create_evse_connector_structure();
-    auto database_handler = create_database_handler();
-    auto evse_security = std::make_shared<EvseSecurityMock>();
-    auto message_queue = create_message_queue(database_handler);
-
-    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
-                                         "/tmp", evse_security, callbacks),
-                 std::invalid_argument);
-}
-
-/*
- * K01.FR.02 states
- *
- *     "The CSMS MAY send a new charging profile for the EVSE that SHALL be used
- *      as a limit schedule for the EV."
- *
- * When using libocpp, a charging station is notified of a new charging profile
- * by means of the set_charging_profiles_callback. In order to ensure that a new
- * profile can be immediately "used as a limit schedule for the EV", a
- * valid set_charging_profiles_callback must be provided.
- *
- * As part of testing that K01.FR.02 is met, we provide the following tests that
- * confirm an OCPP 2.0.1 ChargePoint with smart charging enabled will only
- * consider its collection of callbacks valid if set_charging_profiles_callback
- * is provided.
- */
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.set_charging_profiles_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-/*
- * For completeness, we also test that all other callbacks are checked by
- * all_callbacks_valid.
- */
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksAreInvalidWhenNotProvided) {
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksAreValidWhenAllRequiredCallbacksProvided) {
-    configure_callbacks_with_mocks();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.is_reset_allowed_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfResetCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.reset_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfStopTransactionCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.stop_transaction_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfPauseChargingCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.pause_charging_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.connector_effective_operative_status_changed_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfGetLogRequestCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.get_log_request_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.unlock_connector_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.remote_start_transaction_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.is_reservation_for_token_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.update_firmware_request_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSecurityEventCallbackExists) {
-    configure_callbacks_with_mocks();
-    callbacks.security_event_callback = nullptr;
-
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.variable_changed_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const SetVariableData& set_variable_data)> variable_changed_callback_mock;
-    callbacks.variable_changed_callback = variable_changed_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.validate_network_profile_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<SetNetworkProfileStatusEnum(const int32_t configuration_slot,
-                                                      const NetworkConnectionProfile& network_connection_profile)>
-        validate_network_profile_callback_mock;
-    callbacks.validate_network_profile_callback = validate_network_profile_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture,
-       K01FR02_CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.configure_network_connection_profile_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<bool(const NetworkConnectionProfile& network_connection_profile)>
-        configure_network_connection_profile_callback_mock;
-    callbacks.configure_network_connection_profile_callback =
-        configure_network_connection_profile_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.time_sync_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const ocpp::DateTime& currentTime)> time_sync_callback_mock;
-    callbacks.time_sync_callback = time_sync_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.boot_notification_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const ocpp::v201::BootNotificationResponse& response)> boot_notification_callback_mock;
-    callbacks.boot_notification_callback = boot_notification_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.ocpp_messages_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const std::string& message, MessageDirection direction)> ocpp_messages_callback_mock;
-    callbacks.ocpp_messages_callback = ocpp_messages_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture,
-       K01FR02_CallbacksValidityChecksIfOptionalCSEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.cs_effective_operative_status_changed_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const OperationalStatusEnum new_status)>
-        cs_effective_operative_status_changed_callback_mock;
-    callbacks.cs_effective_operative_status_changed_callback =
-        cs_effective_operative_status_changed_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture,
-       K01FR02_CallbacksValidityChecksIfOptionalEvseEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.evse_effective_operative_status_changed_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const int32_t evse_id, const OperationalStatusEnum new_status)>
-        evse_effective_operative_status_changed_callback_mock;
-    callbacks.evse_effective_operative_status_changed_callback =
-        evse_effective_operative_status_changed_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalGetCustomerInformationCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.get_customer_information_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<std::string(const std::optional<CertificateHashDataType> customer_certificate,
-                                      const std::optional<IdToken> id_token,
-                                      const std::optional<CiString<64>> customer_identifier)>
-        get_customer_information_callback_mock;
-    callbacks.get_customer_information_callback = get_customer_information_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalClearCustomerInformationCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.clear_customer_information_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<std::string(const std::optional<CertificateHashDataType> customer_certificate,
-                                      const std::optional<IdToken> id_token,
-                                      const std::optional<CiString<64>> customer_identifier)>
-        clear_customer_information_callback_mock;
-    callbacks.clear_customer_information_callback = clear_customer_information_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalAllConnectorsUnavailableCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.all_connectors_unavailable_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void()> all_connectors_unavailable_callback_mock;
-    callbacks.all_connectors_unavailable_callback = all_connectors_unavailable_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalDataTransferCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.data_transfer_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<DataTransferResponse(const DataTransferRequest& request)> data_transfer_callback_mock;
-    callbacks.data_transfer_callback = data_transfer_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.transaction_event_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const TransactionEventRequest& transaction_event)> transaction_event_callback_mock;
-    callbacks.transaction_event_callback = transaction_event_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventResponseCallbackIsNotSetOrNotNull) {
-    configure_callbacks_with_mocks();
-
-    callbacks.transaction_event_response_callback = nullptr;
-    EXPECT_FALSE(callbacks.all_callbacks_valid());
-
-    testing::MockFunction<void(const TransactionEventRequest& transaction_event,
-                               const TransactionEventResponse& transaction_event_response)>
-        transaction_event_response_callback_mock;
-    callbacks.transaction_event_response_callback = transaction_event_response_callback_mock.AsStdFunction();
-    EXPECT_TRUE(callbacks.all_callbacks_valid());
-}
-
-TEST_F(ChargePointFixture, K01_SetChargingProfileRequest_ValidatesAndAddsProfile) {
+TEST_F(ChargePointFunctionalityTestFixtureV201, K01_SetChargingProfileRequest_ValidatesAndAddsProfile) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -670,7 +665,7 @@ TEST_F(ChargePointFixture, K01_SetChargingProfileRequest_ValidatesAndAddsProfile
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_TriggersCallbackWhenValid) {
+TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR07_SetChargingProfileRequest_TriggersCallbackWhenValid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -693,7 +688,7 @@ TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_TriggersCallbackWhe
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_DoesNotTriggerCallbackWhenInvalid) {
+TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR07_SetChargingProfileRequest_DoesNotTriggerCallbackWhenInvalid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -721,7 +716,8 @@ TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_DoesNotTriggerCallb
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR22_SetChargingProfileRequest_RejectsChargingStationExternalConstraints) {
+TEST_F(ChargePointFunctionalityTestFixtureV201,
+       K01FR22_SetChargingProfileRequest_RejectsChargingStationExternalConstraints) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -741,7 +737,7 @@ TEST_F(ChargePointFixture, K01FR22_SetChargingProfileRequest_RejectsChargingStat
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError) {
+TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -767,7 +763,7 @@ TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCa
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsTrue_CallsValidateAndAddProfile) {
+TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR29_SmartChargingCtrlrAvailableIsTrue_CallsValidateAndAddProfile) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -793,7 +789,7 @@ TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsTrue_CallsValida
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeSchedule) {
+TEST_F(ChargePointFunctionalityTestFixtureV201, K08_GetCompositeSchedule_CallsCalculateGetCompositeSchedule) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -807,7 +803,8 @@ TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeSc
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeScheduleWithValidProfiles) {
+TEST_F(ChargePointFunctionalityTestFixtureV201,
+       K08_GetCompositeSchedule_CallsCalculateGetCompositeScheduleWithValidProfiles) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -830,7 +827,8 @@ TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeSc
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture, K08FR05_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForNonexistentEVSE) {
+TEST_F(ChargePointFunctionalityTestFixtureV201,
+       K08FR05_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForNonexistentEVSE) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID + 3;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -846,7 +844,8 @@ TEST_F(ChargePointFixture, K08FR05_GetCompositeSchedule_DoesNotCalculateComposit
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture, K08FR07_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForIncorrectChargingRateUnit) {
+TEST_F(ChargePointFunctionalityTestFixtureV201,
+       K08FR07_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForIncorrectChargingRateUnit) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID;
     req.chargingRateUnit = ChargingRateUnitEnum::W;


### PR DESCRIPTION
Once all old constructors no longer are used in other areas of the code, then they can be removed, ensuring the new constructor is used exclusively.

Also, the tests have been split up to use multiple test fixtures that cater to the kind of functionality being tested to make it easier to read and understand for future maintenance.



## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

