### PR TITLE
smart_charging, charge_point: Implement K12

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1390,7 +1390,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | ID        | Status | Remark |
 |-----------|--------|--------|
 | K12.FR.01 |        |        |
-| K12.FR.02 |        |        |
+| K12.FR.02 | ✅     |        |
 | K12.FR.03 |        |        |
 | K12.FR.04 |        |        |
 | K12.FR.05 |        |        |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1392,7 +1392,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K12.FR.01 |        |        |
 | K12.FR.02 | ✅     |        |
 | K12.FR.03 | ✅     |        |
-| K12.FR.04 |        |        |
+| K12.FR.04 | ✅     |        |
 | K12.FR.05 |        |        |
 
 ## SmartCharging - Reset / Release External Charging Limit

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1391,7 +1391,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 |-----------|--------|--------|
 | K12.FR.01 |        |        |
 | K12.FR.02 | ✅     |        |
-| K12.FR.03 |        |        |
+| K12.FR.03 | ✅     |        |
 | K12.FR.04 |        |        |
 | K12.FR.05 |        |        |
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -249,6 +249,13 @@ public:
     ///
     virtual void on_variable_changed(const SetVariableData& set_variable_data) = 0;
 
+    /// \brief Notifies the ChargePoint that a new external limit has been set. This may send a
+    /// NotifyChargingLimitRequest if the \p percentage_delta is greater than our LimitChangeSignificance.
+    /// \param limit the new external limit
+    /// \param percentage_delta the percent changed from the existing limits
+    virtual void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+                                            double percentage_delta) = 0;
+
     /// \brief Data transfer mechanism initiated by charger
     /// \param vendorId
     /// \param messageId
@@ -876,6 +883,9 @@ public:
                            const std::optional<DateTime>& timestamp = std::nullopt) override;
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
+
+    void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+                                    double percentage_delta) override;
 
     std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,
                                                           const std::optional<CiString<50>>& messageId,

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -253,8 +253,9 @@ public:
     /// NotifyChargingLimitRequest if the \p percentage_delta is greater than our LimitChangeSignificance.
     /// \param limit the new external limit
     /// \param percentage_delta the percent changed from the existing limits
-    virtual void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
-                                            double percentage_delta) = 0;
+    /// \param source the source of the external limit (NOTE: Should never be CSO)
+    virtual void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
+                                            ChargingLimitSourceEnum source) = 0;
 
     /// \brief Data transfer mechanism initiated by charger
     /// \param vendorId
@@ -884,8 +885,8 @@ public:
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 
-    void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
-                                    double percentage_delta) override;
+    void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
+                                    ChargingLimitSourceEnum source) override;
 
     std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,
                                                           const std::optional<CiString<50>>& messageId,

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -254,8 +254,8 @@ public:
     /// \param limit the new external limit
     /// \param percentage_delta the percent changed from the existing limits
     /// \param source the source of the external limit (NOTE: Should never be CSO)
-    virtual void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
-                                            ChargingLimitSourceEnum source) = 0;
+    virtual void on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                            double percentage_delta, ChargingLimitSourceEnum source) = 0;
 
     /// \brief Data transfer mechanism initiated by charger
     /// \param vendorId
@@ -885,8 +885,8 @@ public:
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 
-    void on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
-                                    ChargingLimitSourceEnum source) override;
+    void on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                    double percentage_delta, ChargingLimitSourceEnum source) override;
 
     std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,
                                                           const std::optional<CiString<50>>& messageId,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -6,12 +6,14 @@
 
 #include <limits>
 #include <memory>
+#include <variant>
 
 #include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/messages/ClearChargingProfile.hpp>
 #include <ocpp/v201/messages/GetChargingProfiles.hpp>
+#include <ocpp/v201/messages/NotifyChargingLimit.hpp>
 #include <ocpp/v201/messages/SetChargingProfile.hpp>
 #include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
@@ -106,6 +108,10 @@ public:
                                                            const ocpp::DateTime& start_time,
                                                            const ocpp::DateTime& end_time, const int32_t evse_id,
                                                            std::optional<ChargingRateUnitEnum> charging_rate_unit) = 0;
+
+    virtual std::optional<NotifyChargingLimitRequest>
+    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+                                   double percentage_delta) const = 0;
 };
 
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
@@ -177,6 +183,14 @@ public:
                                                    const ocpp::DateTime& start_time, const ocpp::DateTime& end_time,
                                                    const int32_t evse_id,
                                                    std::optional<ChargingRateUnitEnum> charging_rate_unit) override;
+
+    ///
+    /// \brief Determines whether or not we should notify the CSMS of a change to our limits
+    /// based on \p percentage_delta and builds the notification.
+    ///
+    std::optional<NotifyChargingLimitRequest>
+    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+                                   double percentage_delta) const override;
 
 protected:
     ///

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -4,6 +4,7 @@
 #ifndef OCPP_V201_SMART_CHARGING_HPP
 #define OCPP_V201_SMART_CHARGING_HPP
 
+#include "ocpp/v201/comparators.hpp"
 #include <limits>
 #include <memory>
 #include <variant>
@@ -70,6 +71,13 @@ enum class AddChargingProfileSource {
     RequestStartTransactionRequest
 };
 
+struct ConstantChargingLimit {
+    float limit;
+    ChargingRateUnitEnum charging_rate_unit;
+};
+
+bool operator==(const ConstantChargingLimit& a, const ConstantChargingLimit& b);
+
 namespace conversions {
 /// \brief Converts the given ProfileValidationResultEnum \p e to human readable string
 /// \returns a string representation of the ProfileValidationResultEnum
@@ -110,8 +118,8 @@ public:
                                                            std::optional<ChargingRateUnitEnum> charging_rate_unit) = 0;
 
     virtual std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
-                                   ChargingLimitSourceEnum source) const = 0;
+    handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                   double percentage_delta, ChargingLimitSourceEnum source) const = 0;
 };
 
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
@@ -189,8 +197,8 @@ public:
     /// based on \p percentage_delta and builds the notification.
     ///
     std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
-                                   ChargingLimitSourceEnum source) const override;
+    handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                   double percentage_delta, ChargingLimitSourceEnum source) const override;
 
 protected:
     ///

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -110,8 +110,8 @@ public:
                                                            std::optional<ChargingRateUnitEnum> charging_rate_unit) = 0;
 
     virtual std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
-                                   double percentage_delta) const = 0;
+    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
+                                   ChargingLimitSourceEnum source) const = 0;
 };
 
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
@@ -189,8 +189,8 @@ public:
     /// based on \p percentage_delta and builds the notification.
     ///
     std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
-                                   double percentage_delta) const override;
+    handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit, double percentage_delta,
+                                   ChargingLimitSourceEnum source) const override;
 
 protected:
     ///

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1101,8 +1101,8 @@ void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) 
 }
 
 void ChargePoint::on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
-                                             double percentage_delta) {
-    auto request = this->smart_charging_handler->handle_external_limits_changed(limit, percentage_delta);
+                                             double percentage_delta, ChargingLimitSourceEnum source) {
+    auto request = this->smart_charging_handler->handle_external_limits_changed(limit, percentage_delta, source);
     if (request.has_value()) {
         ocpp::Call<NotifyChargingLimitRequest> call(request.value(), this->message_queue->createMessageId());
         this->send<NotifyChargingLimitRequest>(call);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1100,7 +1100,7 @@ void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) 
     this->handle_variable_changed(set_variable_data);
 }
 
-void ChargePoint::on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+void ChargePoint::on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                              double percentage_delta, ChargingLimitSourceEnum source) {
     auto request = this->smart_charging_handler->handle_external_limits_changed(limit, percentage_delta, source);
     if (request.has_value()) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1100,6 +1100,15 @@ void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) 
     this->handle_variable_changed(set_variable_data);
 }
 
+void ChargePoint::on_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+                                             double percentage_delta) {
+    auto request = this->smart_charging_handler->handle_external_limits_changed(limit, percentage_delta);
+    if (request.has_value()) {
+        ocpp::Call<NotifyChargingLimitRequest> call(request.value(), this->message_queue->createMessageId());
+        this->send<NotifyChargingLimitRequest>(call);
+    }
+}
+
 bool ChargePoint::send(CallError call_error) {
     this->message_queue->push(call_error);
     return true;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -20,6 +20,7 @@
 #include <ocpp/common/constants.hpp>
 #include <ocpp/v201/smart_charging.hpp>
 #include <optional>
+#include <variant>
 
 using namespace std::chrono;
 
@@ -751,6 +752,17 @@ CompositeSchedule SmartChargingHandler::calculate_composite_schedule(
     return composite_schedule;
 }
 
+ChargingSchedule create_schedule_from_limit(const float limit) {
+    return ChargingSchedule{
+        .id = 0,
+        .chargingRateUnit = ChargingRateUnitEnum::A,
+        .chargingSchedulePeriod = {ChargingSchedulePeriod{
+            .startPeriod = 0,
+            .limit = limit,
+        }},
+    };
+}
+
 std::optional<NotifyChargingLimitRequest>
 SmartChargingHandler::handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
                                                      double percentage_delta) const {
@@ -758,8 +770,20 @@ SmartChargingHandler::handle_external_limits_changed(const std::variant<float, C
 
     const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
     const float limit_change_significance = this->device_model->get_value<double>(limit_change_cv);
+
+    const auto& notify_charging_limit_cv = ControllerComponentVariables::NotifyChargingLimitWithSchedules;
+    const std::optional<bool> notify_with_schedules =
+        this->device_model->get_optional_value<bool>(notify_charging_limit_cv);
+
     if (percentage_delta > limit_change_significance) {
         request = NotifyChargingLimitRequest{};
+        if (notify_with_schedules.has_value() && notify_with_schedules.value()) {
+            if (const auto* limit_f = std::get_if<float>(&limit)) {
+                request->chargingSchedule = {{create_schedule_from_limit(*limit_f)}};
+            } else if (const auto* limit_s = std::get_if<ChargingSchedule>(&limit)) {
+                request->chargingSchedule = {{*limit_s}};
+            }
+        }
     }
 
     return request;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -26,6 +26,11 @@ using namespace std::chrono;
 
 namespace ocpp::v201 {
 
+bool operator==(const ConstantChargingLimit& a, const ConstantChargingLimit& b) {
+    return std::fabs(a.limit - b.limit) <= std::numeric_limits<float>::epsilon() &&
+           a.charging_rate_unit == b.charging_rate_unit;
+}
+
 namespace conversions {
 std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
     switch (e) {
@@ -752,19 +757,19 @@ CompositeSchedule SmartChargingHandler::calculate_composite_schedule(
     return composite_schedule;
 }
 
-ChargingSchedule create_schedule_from_limit(const float limit) {
+ChargingSchedule create_schedule_from_limit(const ConstantChargingLimit limit) {
     return ChargingSchedule{
         .id = 0,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
+        .chargingRateUnit = limit.charging_rate_unit,
         .chargingSchedulePeriod = {ChargingSchedulePeriod{
             .startPeriod = 0,
-            .limit = limit,
+            .limit = limit.limit,
         }},
     };
 }
 
 std::optional<NotifyChargingLimitRequest>
-SmartChargingHandler::handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+SmartChargingHandler::handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                                      double percentage_delta, ChargingLimitSourceEnum source) const {
     // K12.FR.04
     if (source == ChargingLimitSourceEnum::CSO) {
@@ -786,8 +791,8 @@ SmartChargingHandler::handle_external_limits_changed(const std::variant<float, C
         request = NotifyChargingLimitRequest{};
         request->chargingLimit = {.chargingLimitSource = source};
         if (notify_with_schedules.has_value() && notify_with_schedules.value()) {
-            if (const auto* limit_f = std::get_if<float>(&limit)) {
-                request->chargingSchedule = {{create_schedule_from_limit(*limit_f)}};
+            if (const auto* limit_c = std::get_if<ConstantChargingLimit>(&limit)) {
+                request->chargingSchedule = {{create_schedule_from_limit(*limit_c)}};
             } else if (const auto* limit_s = std::get_if<ChargingSchedule>(&limit)) {
                 request->chargingSchedule = {{*limit_s}};
             }

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -8,6 +8,7 @@
 #include "ocpp/v201/ctrlr_component_variables.hpp"
 #include "ocpp/v201/device_model.hpp"
 #include "ocpp/v201/evse.hpp"
+#include "ocpp/v201/messages/NotifyChargingLimit.hpp"
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include "ocpp/v201/ocpp_enums.hpp"
 #include "ocpp/v201/ocpp_types.hpp"
@@ -748,6 +749,20 @@ CompositeSchedule SmartChargingHandler::calculate_composite_schedule(
     composite_schedule.evseId = evse_id;
 
     return composite_schedule;
+}
+
+std::optional<NotifyChargingLimitRequest>
+SmartChargingHandler::handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
+                                                     double percentage_delta) const {
+    std::optional<NotifyChargingLimitRequest> request = {};
+
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    const float limit_change_significance = this->device_model->get_value<double>(limit_change_cv);
+    if (percentage_delta > limit_change_significance) {
+        request = NotifyChargingLimitRequest{};
+    }
+
+    return request;
 }
 
 } // namespace ocpp::v201

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -765,7 +765,14 @@ ChargingSchedule create_schedule_from_limit(const float limit) {
 
 std::optional<NotifyChargingLimitRequest>
 SmartChargingHandler::handle_external_limits_changed(const std::variant<float, ChargingSchedule>& limit,
-                                                     double percentage_delta) const {
+                                                     double percentage_delta, ChargingLimitSourceEnum source) const {
+    // K12.FR.04
+    if (source == ChargingLimitSourceEnum::CSO) {
+        // The spec does not define what we should do when the source
+        // given is CSO. Here we just throw.
+        throw std::invalid_argument("The source of an external limit should not be CSO.");
+    }
+
     std::optional<NotifyChargingLimitRequest> request = {};
 
     const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
@@ -777,6 +784,7 @@ SmartChargingHandler::handle_external_limits_changed(const std::variant<float, C
 
     if (percentage_delta > limit_change_significance) {
         request = NotifyChargingLimitRequest{};
+        request->chargingLimit = {.chargingLimitSource = source};
         if (notify_with_schedules.has_value() && notify_with_schedules.value()) {
             if (const auto* limit_f = std::get_if<float>(&limit)) {
                 request->chargingSchedule = {{create_schedule_from_limit(*limit_f)}};

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -9,7 +9,7 @@
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include "ocpp/v201/smart_charging.hpp"
 
-typedef std::variant<float, ocpp::v201::ChargingSchedule> ChargingLimitVariant;
+typedef std::variant<ocpp::v201::ConstantChargingLimit, ocpp::v201::ChargingSchedule> ChargingLimitVariant;
 
 namespace ocpp::v201 {
 class SmartChargingHandlerMock : public SmartChargingHandlerInterface {

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -29,6 +29,7 @@ public:
                  const ocpp::DateTime& end_time, const int32_t evse_id,
                  std::optional<ChargingRateUnitEnum> charging_rate_unit));
     MOCK_METHOD(std::optional<NotifyChargingLimitRequest>, handle_external_limits_changed,
-                (const ChargingLimitVariant& limit, double percentage_delta), (const, override));
+                (const ChargingLimitVariant& limit, double percentage_delta, ChargingLimitSourceEnum source),
+                (const, override));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -3,10 +3,13 @@
 
 #include "gmock/gmock.h"
 #include <cstdint>
+#include <variant>
 #include <vector>
 
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include "ocpp/v201/smart_charging.hpp"
+
+typedef std::variant<float, ocpp::v201::ChargingSchedule> ChargingLimitVariant;
 
 namespace ocpp::v201 {
 class SmartChargingHandlerMock : public SmartChargingHandlerInterface {
@@ -25,5 +28,7 @@ public:
                 (std::vector<ChargingProfile> & valid_profiles, const ocpp::DateTime& start_time,
                  const ocpp::DateTime& end_time, const int32_t evse_id,
                  std::optional<ChargingRateUnitEnum> charging_rate_unit));
+    MOCK_METHOD(std::optional<NotifyChargingLimitRequest>, handle_external_limits_changed,
+                (const ChargingLimitVariant& limit, double percentage_delta), (const, override));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -953,11 +953,14 @@ TEST_F(ChargepointTestFixtureV201, K12_OnExternalLimitsChanged_CallsHandler) {
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
                             "test");
 
-    float limit = 100.0;
+    ConstantChargingLimit limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
-    const std::variant<float, ChargingSchedule> new_limit(limit);
+    const std::variant<ConstantChargingLimit, ChargingSchedule> new_limit(limit);
 
     EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(new_limit, deltaChanged, source));
 

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -955,12 +955,13 @@ TEST_F(ChargepointTestFixtureV201, K12_OnExternalLimitsChanged_CallsHandler) {
 
     float limit = 100.0;
     double deltaChanged = 0.2;
+    auto source = ChargingLimitSourceEnum::Other;
 
     const std::variant<float, ChargingSchedule> new_limit(limit);
 
-    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(new_limit, deltaChanged));
+    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(new_limit, deltaChanged, source));
 
-    charge_point->on_external_limits_changed(new_limit, deltaChanged);
+    charge_point->on_external_limits_changed(new_limit, deltaChanged, source);
 }
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -17,12 +17,14 @@
 #include "ocpp/v201/smart_charging.hpp"
 #include "ocpp/v201/types.hpp"
 #include "smart_charging_handler_mock.hpp"
+#include "smart_charging_test_utils.hpp"
 #include "gmock/gmock.h"
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
+#include <variant>
 
 static const int DEFAULT_EVSE_ID = 1;
 static const int DEFAULT_PROFILE_ID = 1;
@@ -944,6 +946,21 @@ TEST_F(ChargepointTestFixtureV201, K02FR05_TransactionEnds_WillDeleteTxProfilesW
                 delete_transaction_tx_profiles(transaction->get_transaction().transactionId.get()));
     charge_point->on_transaction_finished(DEFAULT_EVSE_ID, timestamp, MeterValue(), ReasonEnum::StoppedByEV,
                                           TriggerReasonEnum::StopAuthorized, {}, {}, ChargingStateEnum::EVConnected);
+}
+
+TEST_F(ChargepointTestFixtureV201, K12_OnExternalLimitsChanged_CallsHandler) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
+                            "test");
+
+    float limit = 100.0;
+    double deltaChanged = 0.2;
+
+    const std::variant<float, ChargingSchedule> new_limit(limit);
+
+    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(new_limit, deltaChanged));
+
+    charge_point->on_external_limits_changed(new_limit, deltaChanged);
 }
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -32,6 +32,8 @@
 #include <sstream>
 #include <vector>
 
+#include "smart_charging_test_utils.hpp"
+
 namespace ocpp::v201 {
 
 static const int NR_OF_EVSES = 2;
@@ -1651,6 +1653,94 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
+}
+
+TEST_F(
+    SmartChargingHandlerTestFixtureV201,
+    K12FR03_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_EnableChargingLimitWithSchedulesTrue_IncludesScheduleFromInteger) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
+                            "test");
+    const auto& notify_charging_limit_cv = ControllerComponentVariables::NotifyChargingLimitWithSchedules;
+    device_model->set_value(notify_charging_limit_cv.component, notify_charging_limit_cv.variable.value(),
+                            AttributeEnum::Actual, "true", "test");
+
+    float new_limit = 100.0;
+    double deltaChanged = 0.2;
+
+    auto charging_schedule = ChargingSchedule{.id = 0,
+                                              .chargingRateUnit = ChargingRateUnitEnum::A,
+                                              .chargingSchedulePeriod = {ChargingSchedulePeriod{
+                                                  .startPeriod = 0,
+                                                  .limit = new_limit,
+                                              }}};
+
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsTrue());
+    ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsTrue());
+    ASSERT_THAT(resp->chargingSchedule.value(), testing::Contains(charging_schedule));
+}
+
+TEST_F(
+    SmartChargingHandlerTestFixtureV201,
+    K12FR03_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_EnableChargingLimitWithSchedulesTrue_IncludesGivenSchedule) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
+                            "test");
+    const auto& notify_charging_limit_cv = ControllerComponentVariables::NotifyChargingLimitWithSchedules;
+    device_model->set_value(notify_charging_limit_cv.component, notify_charging_limit_cv.variable.value(),
+                            AttributeEnum::Actual, "true", "test");
+
+    double deltaChanged = 0.2;
+
+    auto charging_schedule = ChargingSchedule{.id = 0,
+                                              .chargingRateUnit = ChargingRateUnitEnum::W,
+                                              .chargingSchedulePeriod = {ChargingSchedulePeriod{
+                                                  .startPeriod = 0,
+                                                  .limit = 20,
+                                              }}};
+
+    auto resp = handler.handle_external_limits_changed(charging_schedule, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsTrue());
+    ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsTrue());
+    ASSERT_THAT(resp->chargingSchedule.value(), testing::Contains(charging_schedule));
+}
+
+TEST_F(
+    SmartChargingHandlerTestFixtureV201,
+    K12FR03_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_EnableChargingLimitWithSchedulesUnset_NoSchedule) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
+                            "test");
+
+    float new_limit = 100.0;
+    double deltaChanged = 0.2;
+
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsTrue());
+    ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsFalse());
+}
+
+TEST_F(
+    SmartChargingHandlerTestFixtureV201,
+    K12FR03_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_EnableChargingLimitWithSchedulesFalse_NoSchedule) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
+                            "test");
+    const auto& notify_charging_limit_cv = ControllerComponentVariables::NotifyChargingLimitWithSchedules;
+    device_model->set_value(notify_charging_limit_cv.component, notify_charging_limit_cv.variable.value(),
+                            AttributeEnum::Actual, "false", "test");
+
+    float new_limit = 100.0;
+    double deltaChanged = 0.2;
+
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsTrue());
+    ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsFalse());
 }
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1621,7 +1621,10 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.5",
                             "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
@@ -1636,7 +1639,10 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.2",
                             "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
@@ -1651,7 +1657,10 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
                             "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
@@ -1662,7 +1671,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
 
 TEST_F(
     SmartChargingHandlerTestFixtureV201,
-    K12FR03_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_EnableChargingLimitWithSchedulesTrue_IncludesScheduleFromInteger) {
+    K12FR03_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_EnableChargingLimitWithSchedulesTrue_IncludesScheduleFromConstantLimit) {
     const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
                             "test");
@@ -1670,15 +1679,18 @@ TEST_F(
     device_model->set_value(notify_charging_limit_cv.component, notify_charging_limit_cv.variable.value(),
                             AttributeEnum::Actual, "true", "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 50.0,
+        .charging_rate_unit = ChargingRateUnitEnum::W,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
     auto charging_schedule = ChargingSchedule{.id = 0,
-                                              .chargingRateUnit = ChargingRateUnitEnum::A,
+                                              .chargingRateUnit = new_limit.charging_rate_unit,
                                               .chargingSchedulePeriod = {ChargingSchedulePeriod{
                                                   .startPeriod = 0,
-                                                  .limit = new_limit,
+                                                  .limit = new_limit.limit,
                                               }}};
 
     auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source);
@@ -1722,7 +1734,10 @@ TEST_F(
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
                             "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
@@ -1742,7 +1757,10 @@ TEST_F(
     device_model->set_value(notify_charging_limit_cv.component, notify_charging_limit_cv.variable.value(),
                             AttributeEnum::Actual, "false", "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
@@ -1757,7 +1775,10 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K12FR04_HandleExternalLimitsChanged_
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
                             "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::SO;
 
@@ -1772,7 +1793,10 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K12FR04_HandleExternalLimitsChanged_
     device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
                             "test");
 
-    float new_limit = 100.0;
+    ConstantChargingLimit new_limit = {
+        .limit = 100.0,
+        .charging_rate_unit = ChargingRateUnitEnum::A,
+    };
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::CSO;
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1611,4 +1611,46 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K05FR02_RequestStartTransactionReque
     ASSERT_THAT(sut, testing::Eq(ProfileValidationResultEnum::RequestStartTransactionNonTxProfile));
 }
 
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K12FR02_HandleExternalLimitsChanged_LimitChangeSignificanceNotMet_ReturnNone) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.5",
+                            "test");
+
+    float new_limit = 100.0;
+    double deltaChanged = 0.2;
+
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsFalse());
+}
+
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K12FR02_HandleExternalLimitsChanged_LimitChangeSignificanceEqual_ReturnNone) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.2",
+                            "test");
+
+    float new_limit = 100.0;
+    double deltaChanged = 0.2;
+
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsFalse());
+}
+
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K12FR02_HandleExternalLimitsChanged_LimitChangeSignificanceExceeded_ReturnNotifyChargingLimitRequest) {
+    const auto& limit_change_cv = ControllerComponentVariables::LimitChangeSignificance;
+    device_model->set_value(limit_change_cv.component, limit_change_cv.variable.value(), AttributeEnum::Actual, "0.1",
+                            "test");
+
+    float new_limit = 100.0;
+    double deltaChanged = 0.2;
+
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged);
+
+    ASSERT_THAT(resp.has_value(), testing::IsTrue());
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

Creates an initial implementation for handling K12 that takes in an external limit and its delta from previous limits and determines whether or not to send a notification to the CSMS.

We expose a public function on the ChargePoint so that some external system (such as the energy manager) may call it to alert us of the external limit.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

