### PR TITLE
Create MessageQueueInterface and Mock

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -466,7 +466,7 @@ public:
         MessageQueue(send_callback, config, {}, databaseHandler) {
     }
 
-    void start() {
+    void start() override {
         this->worker_thread = std::thread([this]() {
             // TODO(kai): implement message timeout
             while (this->running) {
@@ -626,13 +626,13 @@ public:
     }
 
     /// \brief Resets next message to send. Can be used in situation when we dont want to reply to a CALL message
-    void reset_next_message_to_send() {
+    void reset_next_message_to_send() override {
         std::lock_guard<std::recursive_mutex> lk(this->next_message_mutex);
         this->next_message_to_send.reset();
     }
 
     /// \brief Gets all persisted messages of normal message queue and persisted message queue from the database
-    void get_persisted_messages_from_db(bool ignore_security_event_notifications = false) {
+    void get_persisted_messages_from_db(bool ignore_security_event_notifications = false) override {
         std::vector<QueueType> queue_types = {QueueType::Normal, QueueType::Transaction};
         // do for Normal and Transaction queue
         for (const auto queue_type : queue_types) {
@@ -720,7 +720,7 @@ public:
     }
 
     /// \brief Sends a new \p call_error message over the websocket
-    void push(CallError call_error) {
+    void push(CallError call_error) override {
         if (!running) {
             return;
         }
@@ -768,7 +768,7 @@ public:
     /// \brief Enhances a received \p json_message with additional meta information, checks if it is a valid CallResult
     /// with a corresponding Call message on top of the queue
     /// \returns the enhanced message
-    EnhancedMessage<M> receive(std::string_view message) {
+    EnhancedMessage<M> receive(std::string_view message) override {
         EnhancedMessage<M> enhanced_message;
 
         enhanced_message.message = json::parse(message);
@@ -821,12 +821,12 @@ public:
         return enhanced_message;
     }
 
-    void reset_in_flight() {
+    void reset_in_flight() override {
         this->in_flight = nullptr;
         this->in_flight_timeout_timer.stop();
     }
 
-    void handle_call_result(EnhancedMessage<M>& enhanced_message) {
+    void handle_call_result(EnhancedMessage<M>& enhanced_message) override {
         if (this->in_flight->uniqueId() == enhanced_message.uniqueId) {
             enhanced_message.call_message = this->in_flight->message;
             enhanced_message.messageType = this->string_to_messagetype(
@@ -860,7 +860,7 @@ public:
     }
 
     /// \brief Handles a message timeout or a CALLERROR. \p enhanced_message_opt is set only in case of CALLERROR
-    void handle_timeout_or_callerror(const std::optional<EnhancedMessage<M>>& enhanced_message_opt) {
+    void handle_timeout_or_callerror(const std::optional<EnhancedMessage<M>>& enhanced_message_opt) override {
         std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
         // We got a timeout iff enhanced_message_opt is empty. Otherwise, enhanced_message_opt contains the CallError.
         bool timeout = !enhanced_message_opt.has_value();
@@ -963,7 +963,7 @@ public:
     }
 
     /// \brief Stops the message queue
-    void stop() {
+    void stop() override {
         EVLOG_debug << "stop()";
         // stop the running thread
         this->running = false;
@@ -973,7 +973,7 @@ public:
     }
 
     /// \brief Pauses the message queue
-    void pause() {
+    void pause() override {
         EVLOG_debug << "pause()";
         std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
         this->pause_resume_ctr++;
@@ -985,7 +985,7 @@ public:
     }
 
     /// \brief Resumes the message queue
-    void resume(std::chrono::seconds delay_on_reconnect) {
+    void resume(std::chrono::seconds delay_on_reconnect) override {
         EVLOG_debug << "resume() called";
         std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
         if (!this->paused) {
@@ -1004,7 +1004,7 @@ public:
         }
     }
 
-    void set_registration_status_accepted() {
+    void set_registration_status_accepted() override {
         {
             std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
             this->is_registration_status_accepted = true;
@@ -1012,37 +1012,37 @@ public:
         this->cv.notify_all();
     }
 
-    bool is_transaction_message_queue_empty() {
+    bool is_transaction_message_queue_empty() override {
         std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
         return this->transaction_message_queue.empty();
     }
 
-    bool contains_transaction_messages(const CiString<36> transaction_id) {
+    bool contains_transaction_messages(const CiString<36> transaction_id) override {
         return false;
     }
 
-    bool contains_stop_transaction_message(const int32_t transaction_id) {
+    bool contains_stop_transaction_message(const int32_t transaction_id) override {
         return false;
     }
 
     /// \brief Set transaction_message_attempts to given \p transaction_message_attempts
-    void update_transaction_message_attempts(const int transaction_message_attempts) {
+    void update_transaction_message_attempts(const int transaction_message_attempts) override {
         this->config.transaction_message_attempts = transaction_message_attempts;
     }
 
     /// \brief Set transaction_message_retry_interval to given \p transaction_message_retry_interval in seconds
-    void update_transaction_message_retry_interval(const int transaction_message_retry_interval) {
+    void update_transaction_message_retry_interval(const int transaction_message_retry_interval) override {
         this->config.transaction_message_retry_interval = transaction_message_retry_interval;
     }
 
     /// \brief Set message_timeout to given \p timeout (in seconds)
-    void update_message_timeout(const int timeout) {
+    void update_message_timeout(const int timeout) override {
         this->config.message_timeout_seconds = timeout;
     }
 
     /// \brief Creates a unique message ID
     /// \returns the unique message ID
-    MessageId createMessageId() {
+    MessageId createMessageId() override {
         std::stringstream s;
         s << this->uuid_generator();
         return MessageId(s.str());
@@ -1050,13 +1050,13 @@ public:
 
     /// \brief Adds the given \p transaction_id to the message_id_transaction_id_map using the key \p
     /// stop_transaction_message_id
-    void add_stopped_transaction_id(std::string stop_transaction_message_id, int32_t transaction_id) {
+    void add_stopped_transaction_id(std::string stop_transaction_message_id, int32_t transaction_id) override {
         EVLOG_debug << "adding " << stop_transaction_message_id << " for transaction " << transaction_id;
         this->message_id_transaction_id_map[stop_transaction_message_id] = transaction_id;
     }
 
     void add_meter_value_message_id(const std::string& start_transaction_message_id,
-                                    const std::string& meter_value_message_id) {
+                                    const std::string& meter_value_message_id) override {
         if (this->start_transaction_mid_meter_values_mid_map.count(start_transaction_message_id)) {
             this->start_transaction_mid_meter_values_mid_map.at(start_transaction_message_id)
                 .push_back(meter_value_message_id);
@@ -1068,7 +1068,7 @@ public:
     }
 
     void notify_start_transaction_handled(const std::string& start_transaction_message_id,
-                                          const int32_t transaction_id) {
+                                          const int32_t transaction_id) override {
         this->cv.notify_one();
 
         // replace transaction id in meter values if start_transaction_message_id is present in map
@@ -1089,8 +1089,8 @@ public:
         this->start_transaction_mid_meter_values_mid_map.erase(start_transaction_message_id);
     }
 
-    M string_to_messagetype(const std::string& s);
-    std::string messagetype_to_string(M m);
+    M string_to_messagetype(const std::string& s) override;
+    std::string messagetype_to_string(M m) override;
 };
 
 } // namespace ocpp

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -164,7 +164,7 @@ bool allowed_to_send_message(const ControlMessage<M>& message, const DateTime& t
     return true;
 }
 
-template <typename M, class Derived> class MessageQueueInterface {
+template <typename M, typename Derived> class MessageQueueInterface {
 public:
     virtual ~MessageQueueInterface() {
     }
@@ -180,7 +180,7 @@ public:
     }
     virtual void push(CallError call_error) = 0;
     template <class T> std::future<EnhancedMessage<M>> push_async(Call<T> call) {
-        static_cast<Derived*>(this)->push_async(call);
+        return static_cast<Derived*>(this)->push_async(call);
     }
 
     virtual EnhancedMessage<M> receive(std::string_view message) = 0;

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -171,8 +171,11 @@ public:
     virtual void start() = 0;
     virtual void reset_next_message_to_send() = 0;
     virtual void get_persisted_messages_from_db(bool ignore_security_event_notifications = false) = 0;
+
+    /// \brief pushes a new \p call message onto the message queue
     template <class T> void push(Call<T> call, const bool stall_until_accepted = false) {
-        static_cast<Derived*>(this)->push(call, stall_until_accepted);
+        json call_json = call;
+        this->push(call_json, stall_until_accepted);
     }
     virtual void push(const json& message, const bool stall_until_accepted = false) = 0;
     template <class T> void push(CallResult<T> call_result) {
@@ -670,16 +673,7 @@ public:
         }
     }
 
-    /// \brief pushes a new \p call message onto the message queue
-    template <class T> void push(Call<T> call, const bool stall_until_accepted = false) {
-        if (!running) {
-            return;
-        }
-        json call_json = call;
-        push(call_json, stall_until_accepted);
-    }
-
-    void push(const json& message, const bool stall_until_accepted = false) {
+    void push(const json& message, const bool stall_until_accepted = false) override {
         if (!running) {
             return;
         }

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -96,7 +96,7 @@ private:
 
     std::unique_ptr<Websocket> websocket;
     Everest::SteadyTimer websocket_timer;
-    std::unique_ptr<MessageQueue<v16::MessageType>> message_queue;
+    std::unique_ptr<MessageQueueInterface<v16::MessageType, MessageQueue<v16::MessageType>>> message_queue;
     std::map<int32_t, std::shared_ptr<Connector>> connectors;
     std::unique_ptr<SmartChargingHandler> smart_charging_handler;
     int32_t heartbeat_interval;

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -96,7 +96,7 @@ private:
 
     std::unique_ptr<Websocket> websocket;
     Everest::SteadyTimer websocket_timer;
-    std::unique_ptr<MessageQueueInterface<v16::MessageType, MessageQueue<v16::MessageType>>> message_queue;
+    std::unique_ptr<MessageQueueInterface<v16::MessageType>> message_queue;
     std::map<int32_t, std::shared_ptr<Connector>> connectors;
     std::unique_ptr<SmartChargingHandler> smart_charging_handler;
     int32_t heartbeat_interval;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -327,7 +327,7 @@ private:
     std::unique_ptr<ConnectivityManager> connectivity_manager;
 
     // utility
-    std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;
+    std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue;
     std::shared_ptr<DatabaseHandler> database_handler;
 
     std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;
@@ -806,10 +806,12 @@ public:
     /// \param message_log_path Path to where logfiles are written to
     /// \param evse_security Pointer to evse_security that manages security related operations
     /// \param callbacks Callbacks that will be registered for ChargePoint
-    ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
-                std::shared_ptr<DatabaseHandler> database_handler,
-                std::shared_ptr<MessageQueue<v201::MessageType>> message_queue, const std::string& message_log_path,
-                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+    ChargePoint(
+        const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
+        std::shared_ptr<DatabaseHandler> database_handler,
+        std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue,
+        const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+        const Callbacks& callbacks);
 
     ~ChargePoint();
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -327,7 +327,7 @@ private:
     std::unique_ptr<ConnectivityManager> connectivity_manager;
 
     // utility
-    std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue;
+    std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue;
     std::shared_ptr<DatabaseHandler> database_handler;
 
     std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;
@@ -806,12 +806,11 @@ public:
     /// \param message_log_path Path to where logfiles are written to
     /// \param evse_security Pointer to evse_security that manages security related operations
     /// \param callbacks Callbacks that will be registered for ChargePoint
-    ChargePoint(
-        const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
-        std::shared_ptr<DatabaseHandler> database_handler,
-        std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue,
-        const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
-        const Callbacks& callbacks);
+    ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
+                std::shared_ptr<DatabaseHandler> database_handler,
+                std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue,
+                const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                const Callbacks& callbacks);
 
     ~ChargePoint();
 

--- a/lib/ocpp/v16/message_queue.cpp
+++ b/lib/ocpp/v16/message_queue.cpp
@@ -42,4 +42,17 @@ template <> std::string MessageQueue<v16::MessageType>::messagetype_to_string(v1
     return v16::conversions::messagetype_to_string(m);
 }
 
+template <> bool MessageQueue<v16::MessageType>::contains_stop_transaction_message(const int32_t transaction_id) {
+    std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
+    for (const auto control_message : this->transaction_message_queue) {
+        if (control_message->messageType == v16::MessageType::StopTransaction) {
+            v16::StopTransactionRequest req = control_message->message.at(CALL_PAYLOAD);
+            if (req.transactionId == transaction_id) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 } // namespace ocpp

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -35,11 +35,12 @@ static DisplayMessageContent message_content_to_display_message_content(const Me
 static std::optional<MessageInfo> display_message_to_message_info_type(const DisplayMessage& display_message);
 static DisplayMessage message_info_to_display_message(const MessageInfo& message_info);
 
-ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
-                         std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
-                         std::shared_ptr<MessageQueue<v201::MessageType>> message_queue,
-                         const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
-                         const Callbacks& callbacks) :
+ChargePoint::ChargePoint(
+    const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
+    std::shared_ptr<DatabaseHandler> database_handler,
+    std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue,
+    const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+    const Callbacks& callbacks) :
     ocpp::ChargingStationBase(evse_security),
     message_queue(message_queue),
     device_model(device_model),

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -35,12 +35,11 @@ static DisplayMessageContent message_content_to_display_message_content(const Me
 static std::optional<MessageInfo> display_message_to_message_info_type(const DisplayMessage& display_message);
 static DisplayMessage message_info_to_display_message(const MessageInfo& message_info);
 
-ChargePoint::ChargePoint(
-    const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
-    std::shared_ptr<DatabaseHandler> database_handler,
-    std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue,
-    const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
-    const Callbacks& callbacks) :
+ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                         std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                         std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue,
+                         const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                         const Callbacks& callbacks) :
     ocpp::ChargingStationBase(evse_security),
     message_queue(message_queue),
     device_model(device_model),

--- a/lib/ocpp/v201/message_queue.cpp
+++ b/lib/ocpp/v201/message_queue.cpp
@@ -45,4 +45,17 @@ template <> std::string MessageQueue<v201::MessageType>::messagetype_to_string(c
     return v201::conversions::messagetype_to_string(m);
 }
 
+template <> bool MessageQueue<v201::MessageType>::contains_transaction_messages(const CiString<36> transaction_id) {
+    std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
+    for (const auto control_message : this->transaction_message_queue) {
+        if (control_message->messageType == v201::MessageType::TransactionEvent) {
+            v201::TransactionEventRequest req = control_message->message.at(CALL_PAYLOAD);
+            if (req.transactionInfo.transactionId == transaction_id) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 } // namespace ocpp

--- a/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
@@ -1,0 +1,39 @@
+#include "ocpp/common/message_queue.hpp"
+
+#include "gmock/gmock.h"
+
+namespace ocpp {
+
+class MessageQueueMock : public MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>> {
+    public:
+        MOCK_METHOD(void, start, ());
+        MOCK_METHOD(void, reset_next_message_to_send, ());
+        MOCK_METHOD(void, get_persisted_messages_from_db, (bool ignore_security_event_notifications));
+        MOCK_METHOD(void, push, (const json& message, const bool stall_until_accepted));
+        MOCK_METHOD(void, push, (CallError call_error));
+        MOCK_METHOD(EnhancedMessage<v201::MessageType>, receive, (std::string_view message));
+        MOCK_METHOD(void, reset_in_flight, ());
+        MOCK_METHOD(void, handle_call_result, (EnhancedMessage<v201::MessageType> & enhanced_message));
+        MOCK_METHOD(void, handle_timeout_or_callerror,
+                    (const std::optional<EnhancedMessage<v201::MessageType>>& enhanced_message_opt));
+        MOCK_METHOD(void, stop, ());
+        MOCK_METHOD(void, pause, ());
+        MOCK_METHOD(void, resume, (std::chrono::seconds delay_on_reconnect));
+        MOCK_METHOD(void, set_registration_status_accepted, ());
+        MOCK_METHOD(bool, is_transaction_message_queue_empty, ());
+        MOCK_METHOD(bool, contains_transaction_messages, (const CiString<36> transaction_id));
+        MOCK_METHOD(bool, contains_stop_transaction_message, (const int32_t transaction_id));
+        MOCK_METHOD(void, update_transaction_message_attempts, (const int transaction_message_attempts));
+        MOCK_METHOD(void, update_transaction_message_retry_interval, (const int transaction_message_retry_interval));
+        MOCK_METHOD(void, update_message_timeout, (const int timeout));
+        MOCK_METHOD(MessageId, createMessageId, ());
+        MOCK_METHOD(void, add_stopped_transaction_id,
+                    (std::string stop_transaction_message_id, int32_t transaction_id));
+        MOCK_METHOD(void, add_meter_value_message_id,
+                    (const std::string& start_transaction_message_id, const std::string& meter_value_message_id));
+        MOCK_METHOD(void, notify_start_transaction_handled,
+                    (const std::string& start_transaction_message_id, const int32_t transaction_id));
+        MOCK_METHOD(v201::MessageType, string_to_messagetype, (const std::string& s));
+        MOCK_METHOD(std::string, messagetype_to_string, (v201::MessageType m));
+    };
+}

--- a/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
@@ -4,13 +4,16 @@
 
 namespace ocpp {
 
-class MessageQueueMock : public MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>> {
+class MessageQueueMock : public MessageQueueInterface<v201::MessageType> {
 public:
     MOCK_METHOD(void, start, ());
     MOCK_METHOD(void, reset_next_message_to_send, ());
     MOCK_METHOD(void, get_persisted_messages_from_db, (bool ignore_security_event_notifications));
     MOCK_METHOD(void, push, (const json& message, const bool stall_until_accepted));
+    MOCK_METHOD(void, push_call_result, (const json& call_result_json, const MessageId& unique_id));
     MOCK_METHOD(void, push, (CallError call_error));
+    MOCK_METHOD(std::future<EnhancedMessage<v201::MessageType>>, push_async_internal,
+                (std::shared_ptr<ControlMessage<v201::MessageType>> message));
     MOCK_METHOD(EnhancedMessage<v201::MessageType>, receive, (std::string_view message));
     MOCK_METHOD(void, reset_in_flight, ());
     MOCK_METHOD(void, handle_call_result, (EnhancedMessage<v201::MessageType> & enhanced_message));

--- a/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
@@ -5,35 +5,34 @@
 namespace ocpp {
 
 class MessageQueueMock : public MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>> {
-    public:
-        MOCK_METHOD(void, start, ());
-        MOCK_METHOD(void, reset_next_message_to_send, ());
-        MOCK_METHOD(void, get_persisted_messages_from_db, (bool ignore_security_event_notifications));
-        MOCK_METHOD(void, push, (const json& message, const bool stall_until_accepted));
-        MOCK_METHOD(void, push, (CallError call_error));
-        MOCK_METHOD(EnhancedMessage<v201::MessageType>, receive, (std::string_view message));
-        MOCK_METHOD(void, reset_in_flight, ());
-        MOCK_METHOD(void, handle_call_result, (EnhancedMessage<v201::MessageType> & enhanced_message));
-        MOCK_METHOD(void, handle_timeout_or_callerror,
-                    (const std::optional<EnhancedMessage<v201::MessageType>>& enhanced_message_opt));
-        MOCK_METHOD(void, stop, ());
-        MOCK_METHOD(void, pause, ());
-        MOCK_METHOD(void, resume, (std::chrono::seconds delay_on_reconnect));
-        MOCK_METHOD(void, set_registration_status_accepted, ());
-        MOCK_METHOD(bool, is_transaction_message_queue_empty, ());
-        MOCK_METHOD(bool, contains_transaction_messages, (const CiString<36> transaction_id));
-        MOCK_METHOD(bool, contains_stop_transaction_message, (const int32_t transaction_id));
-        MOCK_METHOD(void, update_transaction_message_attempts, (const int transaction_message_attempts));
-        MOCK_METHOD(void, update_transaction_message_retry_interval, (const int transaction_message_retry_interval));
-        MOCK_METHOD(void, update_message_timeout, (const int timeout));
-        MOCK_METHOD(MessageId, createMessageId, ());
-        MOCK_METHOD(void, add_stopped_transaction_id,
-                    (std::string stop_transaction_message_id, int32_t transaction_id));
-        MOCK_METHOD(void, add_meter_value_message_id,
-                    (const std::string& start_transaction_message_id, const std::string& meter_value_message_id));
-        MOCK_METHOD(void, notify_start_transaction_handled,
-                    (const std::string& start_transaction_message_id, const int32_t transaction_id));
-        MOCK_METHOD(v201::MessageType, string_to_messagetype, (const std::string& s));
-        MOCK_METHOD(std::string, messagetype_to_string, (v201::MessageType m));
-    };
-}
+public:
+    MOCK_METHOD(void, start, ());
+    MOCK_METHOD(void, reset_next_message_to_send, ());
+    MOCK_METHOD(void, get_persisted_messages_from_db, (bool ignore_security_event_notifications));
+    MOCK_METHOD(void, push, (const json& message, const bool stall_until_accepted));
+    MOCK_METHOD(void, push, (CallError call_error));
+    MOCK_METHOD(EnhancedMessage<v201::MessageType>, receive, (std::string_view message));
+    MOCK_METHOD(void, reset_in_flight, ());
+    MOCK_METHOD(void, handle_call_result, (EnhancedMessage<v201::MessageType> & enhanced_message));
+    MOCK_METHOD(void, handle_timeout_or_callerror,
+                (const std::optional<EnhancedMessage<v201::MessageType>>& enhanced_message_opt));
+    MOCK_METHOD(void, stop, ());
+    MOCK_METHOD(void, pause, ());
+    MOCK_METHOD(void, resume, (std::chrono::seconds delay_on_reconnect));
+    MOCK_METHOD(void, set_registration_status_accepted, ());
+    MOCK_METHOD(bool, is_transaction_message_queue_empty, ());
+    MOCK_METHOD(bool, contains_transaction_messages, (const CiString<36> transaction_id));
+    MOCK_METHOD(bool, contains_stop_transaction_message, (const int32_t transaction_id));
+    MOCK_METHOD(void, update_transaction_message_attempts, (const int transaction_message_attempts));
+    MOCK_METHOD(void, update_transaction_message_retry_interval, (const int transaction_message_retry_interval));
+    MOCK_METHOD(void, update_message_timeout, (const int timeout));
+    MOCK_METHOD(MessageId, createMessageId, ());
+    MOCK_METHOD(void, add_stopped_transaction_id, (std::string stop_transaction_message_id, int32_t transaction_id));
+    MOCK_METHOD(void, add_meter_value_message_id,
+                (const std::string& start_transaction_message_id, const std::string& meter_value_message_id));
+    MOCK_METHOD(void, notify_start_transaction_handled,
+                (const std::string& start_transaction_message_id, const int32_t transaction_id));
+    MOCK_METHOD(v201::MessageType, string_to_messagetype, (const std::string& s));
+    MOCK_METHOD(std::string, messagetype_to_string, (v201::MessageType m));
+};
+} // namespace ocpp

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -5,6 +5,7 @@
 #include "everest/logging.hpp"
 #include "evse_security_mock.hpp"
 #include "lib/ocpp/common/database_testing_utils.hpp"
+#include "message_queue_mock.hpp"
 #include "ocpp/common/call_types.hpp"
 #include "ocpp/common/message_queue.hpp"
 #include "ocpp/v201/charge_point.hpp"
@@ -130,39 +131,6 @@ public:
         auto database_connection = std::make_unique<common::DatabaseConnection>(fs::path("/tmp/ocpp201") / "cp.db");
         return std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V201);
     }
-
-    class MessageQueueMock : public MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>> {
-    public:
-        MOCK_METHOD(void, start, ());
-        MOCK_METHOD(void, reset_next_message_to_send, ());
-        MOCK_METHOD(void, get_persisted_messages_from_db, (bool ignore_security_event_notifications));
-        MOCK_METHOD(void, push, (const json& message, const bool stall_until_accepted));
-        MOCK_METHOD(void, push, (CallError call_error));
-        MOCK_METHOD(EnhancedMessage<v201::MessageType>, receive, (std::string_view message));
-        MOCK_METHOD(void, reset_in_flight, ());
-        MOCK_METHOD(void, handle_call_result, (EnhancedMessage<v201::MessageType> & enhanced_message));
-        MOCK_METHOD(void, handle_timeout_or_callerror,
-                    (const std::optional<EnhancedMessage<v201::MessageType>>& enhanced_message_opt));
-        MOCK_METHOD(void, stop, ());
-        MOCK_METHOD(void, pause, ());
-        MOCK_METHOD(void, resume, (std::chrono::seconds delay_on_reconnect));
-        MOCK_METHOD(void, set_registration_status_accepted, ());
-        MOCK_METHOD(bool, is_transaction_message_queue_empty, ());
-        MOCK_METHOD(bool, contains_transaction_messages, (const CiString<36> transaction_id));
-        MOCK_METHOD(bool, contains_stop_transaction_message, (const int32_t transaction_id));
-        MOCK_METHOD(void, update_transaction_message_attempts, (const int transaction_message_attempts));
-        MOCK_METHOD(void, update_transaction_message_retry_interval, (const int transaction_message_retry_interval));
-        MOCK_METHOD(void, update_message_timeout, (const int timeout));
-        MOCK_METHOD(MessageId, createMessageId, ());
-        MOCK_METHOD(void, add_stopped_transaction_id,
-                    (std::string stop_transaction_message_id, int32_t transaction_id));
-        MOCK_METHOD(void, add_meter_value_message_id,
-                    (const std::string& start_transaction_message_id, const std::string& meter_value_message_id));
-        MOCK_METHOD(void, notify_start_transaction_handled,
-                    (const std::string& start_transaction_message_id, const int32_t transaction_id));
-        MOCK_METHOD(v201::MessageType, string_to_messagetype, (const std::string& s));
-        MOCK_METHOD(std::string, messagetype_to_string, (v201::MessageType m));
-    };
 
     std::shared_ptr<MessageQueueMock> create_message_queue(std::shared_ptr<DatabaseHandler>& database_handler) {
         return std::make_shared<MessageQueueMock>();

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -133,7 +133,7 @@ public:
     }
 
     std::shared_ptr<MessageQueueMock> create_message_queue(std::shared_ptr<DatabaseHandler>& database_handler) {
-        return std::make_shared<MessageQueueMock>();
+        return std::make_shared<testing::NiceMock<MessageQueueMock>>();
     }
 
     void configure_callbacks_with_mocks() {
@@ -566,12 +566,11 @@ public:
     using ChargePoint::handle_message;
     using ChargePoint::smart_charging_handler;
 
-    TestChargePoint(
-        const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
-        std::shared_ptr<DatabaseHandler> database_handler,
-        std::shared_ptr<MessageQueueInterface<v201::MessageType, MessageQueue<v201::MessageType>>> message_queue,
-        const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
-        const Callbacks& callbacks, std::shared_ptr<SmartChargingHandlerInterface> smart_charging_handler) :
+    TestChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                    std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                    std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue,
+                    const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                    const Callbacks& callbacks, std::shared_ptr<SmartChargingHandlerInterface> smart_charging_handler) :
         ChargePoint(evse_connector_structure, device_model, database_handler, message_queue, message_log_path,
                     evse_security, callbacks) {
         this->smart_charging_handler = smart_charging_handler;
@@ -626,13 +625,15 @@ public:
 
     std::unique_ptr<TestChargePoint> create_charge_point() {
         auto database_handler = create_database_handler();
+        message_queue = create_message_queue(database_handler);
         configure_callbacks_with_mocks();
         auto charge_point = std::make_unique<TestChargePoint>(
-            create_evse_connector_structure(), device_model, database_handler, create_message_queue(database_handler),
-            TEMP_OUTPUT_PATH, std::make_shared<EvseSecurityMock>(), callbacks, smart_charging_handler);
+            create_evse_connector_structure(), device_model, database_handler, message_queue, TEMP_OUTPUT_PATH,
+            std::make_shared<EvseSecurityMock>(), callbacks, smart_charging_handler);
         return charge_point;
     }
 
+    std::shared_ptr<MessageQueueMock> message_queue;
     boost::uuids::random_generator uuid_generator;
     std::shared_ptr<SmartChargingHandlerMock> smart_charging_handler;
     std::unique_ptr<TestChargePoint> charge_point;


### PR DESCRIPTION
This change creates an Interface for the MessageQueue in order to create a MessageQueueMock to allow test code to be written more easily.

~The templates involved might look strange, but it uses the Curiously Recurring Template Pattern (CRTP) to allow a base class (MessageQueueInterface) to define a function that calls a template function on a derived class (MessageQueue<v201::MessageType> for instance).  Due to the template functions related to push() not being able to be defined as pure virtual, the CRTP was the way to create an interface and mock while still allowing the code to function as is.~ Nevermind, it is a lot nicer now.

The contains_transaction_messages() and contains_stop_transaction_message() now move their type-specific code into template specialization code in their respective versioned message_queue.cpp files.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

