### PR TITLE
misc: Add evse_id to external limits handler

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -251,10 +251,12 @@ public:
 
     /// \brief Notifies the ChargePoint that a new external limit has been set. This may send a
     /// NotifyChargingLimitRequest if the \p percentage_delta is greater than our LimitChangeSignificance.
+    /// \param evse_id ID of the EVSE with the external limit
     /// \param limit the new external limit
     /// \param percentage_delta the percent changed from the existing limits
     /// \param source the source of the external limit (NOTE: Should never be CSO)
-    virtual void on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+    virtual void on_external_limits_changed(std::optional<int32_t> evse_id,
+                                            const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                             double percentage_delta, ChargingLimitSourceEnum source) = 0;
 
     /// \brief Data transfer mechanism initiated by charger
@@ -885,7 +887,8 @@ public:
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 
-    void on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+    void on_external_limits_changed(std::optional<int32_t> evse_id,
+                                    const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                     double percentage_delta, ChargingLimitSourceEnum source) override;
 
     std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -118,7 +118,8 @@ public:
                                                            std::optional<ChargingRateUnitEnum> charging_rate_unit) = 0;
 
     virtual std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+    handle_external_limits_changed(std::optional<int32_t> evse_id,
+                                   const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                    double percentage_delta, ChargingLimitSourceEnum source) const = 0;
 };
 
@@ -197,7 +198,8 @@ public:
     /// based on \p percentage_delta and builds the notification.
     ///
     std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+    handle_external_limits_changed(std::optional<int32_t> evse_id,
+                                   const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                    double percentage_delta, ChargingLimitSourceEnum source) const override;
 
 protected:

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <cstdint>
 #include <ocpp/common/types.hpp>
 #include <ocpp/v201/charge_point.hpp>
 #include <ocpp/v201/ctrlr_component_variables.hpp>
@@ -1100,9 +1101,11 @@ void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) 
     this->handle_variable_changed(set_variable_data);
 }
 
-void ChargePoint::on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+void ChargePoint::on_external_limits_changed(std::optional<int32_t> evse_id,
+                                             const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                              double percentage_delta, ChargingLimitSourceEnum source) {
-    auto request = this->smart_charging_handler->handle_external_limits_changed(limit, percentage_delta, source);
+    auto request =
+        this->smart_charging_handler->handle_external_limits_changed(evse_id, limit, percentage_delta, source);
     if (request.has_value()) {
         ocpp::Call<NotifyChargingLimitRequest> call(request.value(), this->message_queue->createMessageId());
         this->send<NotifyChargingLimitRequest>(call);

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -769,7 +769,8 @@ ChargingSchedule create_schedule_from_limit(const ConstantChargingLimit limit) {
 }
 
 std::optional<NotifyChargingLimitRequest>
-SmartChargingHandler::handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+SmartChargingHandler::handle_external_limits_changed(std::optional<int32_t> evse_id,
+                                                     const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
                                                      double percentage_delta, ChargingLimitSourceEnum source) const {
     // K12.FR.04
     if (source == ChargingLimitSourceEnum::CSO) {
@@ -789,6 +790,7 @@ SmartChargingHandler::handle_external_limits_changed(const std::variant<Constant
 
     if (percentage_delta > limit_change_significance) {
         request = NotifyChargingLimitRequest{};
+        request->evseId = evse_id;
         request->chargingLimit = {.chargingLimitSource = source};
         if (notify_with_schedules.has_value() && notify_with_schedules.value()) {
             if (const auto* limit_c = std::get_if<ConstantChargingLimit>(&limit)) {

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -29,7 +29,8 @@ public:
                  const ocpp::DateTime& end_time, const int32_t evse_id,
                  std::optional<ChargingRateUnitEnum> charging_rate_unit));
     MOCK_METHOD(std::optional<NotifyChargingLimitRequest>, handle_external_limits_changed,
-                (const ChargingLimitVariant& limit, double percentage_delta, ChargingLimitSourceEnum source),
+                (std::optional<int32_t> evse_id, const ChargingLimitVariant& limit, double percentage_delta,
+                 ChargingLimitSourceEnum source),
                 (const, override));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -21,6 +21,7 @@
 #include "gmock/gmock.h"
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <cstdint>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
@@ -962,9 +963,11 @@ TEST_F(ChargepointTestFixtureV201, K12_OnExternalLimitsChanged_CallsHandler) {
 
     const std::variant<ConstantChargingLimit, ChargingSchedule> new_limit(limit);
 
-    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(new_limit, deltaChanged, source));
+    const std::optional<int32_t> evse_id(DEFAULT_EVSE_ID);
 
-    charge_point->on_external_limits_changed(new_limit, deltaChanged, source);
+    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(evse_id, new_limit, deltaChanged, source));
+
+    charge_point->on_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
 }
 
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

We need to set this on the request we send out, so we need to take it in.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

