### PR TITLE
misc: Move evse_id param for external limits funcs

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -255,9 +255,9 @@ public:
     /// \param limit the new external limit
     /// \param percentage_delta the percent changed from the existing limits
     /// \param source the source of the external limit (NOTE: Should never be CSO)
-    virtual void on_external_limits_changed(std::optional<int32_t> evse_id,
-                                            const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
-                                            double percentage_delta, ChargingLimitSourceEnum source) = 0;
+    virtual void on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                            double percentage_delta, ChargingLimitSourceEnum source,
+                                            std::optional<int32_t> evse_id) = 0;
 
     /// \brief Data transfer mechanism initiated by charger
     /// \param vendorId
@@ -887,9 +887,9 @@ public:
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 
-    void on_external_limits_changed(std::optional<int32_t> evse_id,
-                                    const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
-                                    double percentage_delta, ChargingLimitSourceEnum source) override;
+    void on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                    double percentage_delta, ChargingLimitSourceEnum source,
+                                    std::optional<int32_t> evse_id) override;
 
     std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,
                                                           const std::optional<CiString<50>>& messageId,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -118,9 +118,9 @@ public:
                                                            std::optional<ChargingRateUnitEnum> charging_rate_unit) = 0;
 
     virtual std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(std::optional<int32_t> evse_id,
-                                   const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
-                                   double percentage_delta, ChargingLimitSourceEnum source) const = 0;
+    handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                   double percentage_delta, ChargingLimitSourceEnum source,
+                                   std::optional<int32_t> evse_id) const = 0;
 };
 
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
@@ -198,9 +198,9 @@ public:
     /// based on \p percentage_delta and builds the notification.
     ///
     std::optional<NotifyChargingLimitRequest>
-    handle_external_limits_changed(std::optional<int32_t> evse_id,
-                                   const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
-                                   double percentage_delta, ChargingLimitSourceEnum source) const override;
+    handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                   double percentage_delta, ChargingLimitSourceEnum source,
+                                   std::optional<int32_t> evse_id) const override;
 
 protected:
     ///

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1101,11 +1101,11 @@ void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) 
     this->handle_variable_changed(set_variable_data);
 }
 
-void ChargePoint::on_external_limits_changed(std::optional<int32_t> evse_id,
-                                             const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
-                                             double percentage_delta, ChargingLimitSourceEnum source) {
+void ChargePoint::on_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                             double percentage_delta, ChargingLimitSourceEnum source,
+                                             std::optional<int32_t> evse_id) {
     auto request =
-        this->smart_charging_handler->handle_external_limits_changed(evse_id, limit, percentage_delta, source);
+        this->smart_charging_handler->handle_external_limits_changed(limit, percentage_delta, source, evse_id);
     if (request.has_value()) {
         ocpp::Call<NotifyChargingLimitRequest> call(request.value(), this->message_queue->createMessageId());
         this->send<NotifyChargingLimitRequest>(call);

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -769,9 +769,9 @@ ChargingSchedule create_schedule_from_limit(const ConstantChargingLimit limit) {
 }
 
 std::optional<NotifyChargingLimitRequest>
-SmartChargingHandler::handle_external_limits_changed(std::optional<int32_t> evse_id,
-                                                     const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
-                                                     double percentage_delta, ChargingLimitSourceEnum source) const {
+SmartChargingHandler::handle_external_limits_changed(const std::variant<ConstantChargingLimit, ChargingSchedule>& limit,
+                                                     double percentage_delta, ChargingLimitSourceEnum source,
+                                                     std::optional<int32_t> evse_id) const {
     // K12.FR.04
     if (source == ChargingLimitSourceEnum::CSO) {
         // The spec does not define what we should do when the source

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -29,8 +29,8 @@ public:
                  const ocpp::DateTime& end_time, const int32_t evse_id,
                  std::optional<ChargingRateUnitEnum> charging_rate_unit));
     MOCK_METHOD(std::optional<NotifyChargingLimitRequest>, handle_external_limits_changed,
-                (std::optional<int32_t> evse_id, const ChargingLimitVariant& limit, double percentage_delta,
-                 ChargingLimitSourceEnum source),
+                (const ChargingLimitVariant& limit, double percentage_delta, ChargingLimitSourceEnum source,
+                 std::optional<int32_t> evse_id),
                 (const, override));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -965,9 +965,9 @@ TEST_F(ChargepointTestFixtureV201, K12_OnExternalLimitsChanged_CallsHandler) {
 
     const std::optional<int32_t> evse_id(DEFAULT_EVSE_ID);
 
-    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(evse_id, new_limit, deltaChanged, source));
+    EXPECT_CALL(*smart_charging_handler, handle_external_limits_changed(new_limit, deltaChanged, source, evse_id));
 
-    charge_point->on_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    charge_point->on_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 }
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1629,7 +1629,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsFalse());
 }
@@ -1647,7 +1647,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsFalse());
 }
@@ -1665,7 +1665,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
 }
@@ -1694,7 +1694,7 @@ TEST_F(
                                                   .limit = new_limit.limit,
                                               }}};
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
     ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsTrue());
@@ -1721,7 +1721,7 @@ TEST_F(
                                                   .limit = 20,
                                               }}};
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, charging_schedule, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(charging_schedule, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
     ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsTrue());
@@ -1742,7 +1742,7 @@ TEST_F(
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
     ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsFalse());
@@ -1765,7 +1765,7 @@ TEST_F(
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::Other;
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
     ASSERT_THAT(resp->chargingSchedule.has_value(), testing::IsFalse());
@@ -1783,7 +1783,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K12FR04_HandleExternalLimitsChanged_
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::SO;
 
-    auto resp = handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
     ASSERT_THAT(resp->chargingLimit.chargingLimitSource, testing::Eq(source));
@@ -1801,7 +1801,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K12FR04_HandleExternalLimitsChanged_
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::CSO;
 
-    EXPECT_THROW(handler.handle_external_limits_changed(DEFAULT_EVSE_ID, new_limit, deltaChanged, source),
+    EXPECT_THROW(handler.handle_external_limits_changed(new_limit, deltaChanged, source, DEFAULT_EVSE_ID),
                  std::invalid_argument);
 }
 
@@ -1819,7 +1819,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K12_HandleExternalLimitsChanged_Requ
     double deltaChanged = 0.2;
     auto source = ChargingLimitSourceEnum::SO;
 
-    auto resp = handler.handle_external_limits_changed(evse_id, new_limit, deltaChanged, source);
+    auto resp = handler.handle_external_limits_changed(new_limit, deltaChanged, source, evse_id);
 
     ASSERT_THAT(resp.has_value(), testing::IsTrue());
     ASSERT_THAT(resp->chargingLimit.chargingLimitSource, testing::Eq(source));


### PR DESCRIPTION
## Describe your changes

Fixup nr. 2

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

